### PR TITLE
Build both cjs and mjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ typings/
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist-cjs
+dist-esm
 
 # Gatsby files
 .cache/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "@dfinity/nns",
   "version": "0.1.0",
   "description": "",
-  "main": "dist/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-esm/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b && tsc -p tsconfig-cjs.json",
     "test": "jest",
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "module": "./dist-esm/index.js",
   "scripts": {
     "build": "tsc -b && tsc -p tsconfig-cjs.json",
-    "postinstall": "npm ci && npm run build",
+    "postinstall": "npm run build",
     "test": "jest",
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "module": "./dist-esm/index.js",
   "scripts": {
     "build": "tsc -b && tsc -p tsconfig-cjs.json",
-    "postinstall": "npm run build",
+    "postinstall": "npm ci && npm run build",
     "test": "jest",
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "module": "./dist-esm/index.js",
   "scripts": {
     "build": "tsc -b && tsc -p tsconfig-cjs.json",
-    "postinstall": "npm run build",
+    "postinstall": "npm ci --ignore-scripts && npm run build",
     "test": "jest",
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "module": "./dist-esm/index.js",
   "scripts": {
     "build": "tsc -b && tsc -p tsconfig-cjs.json",
+    "postinstall": "npm run build",
     "test": "jest",
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist-cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
+    "target": "es2017",
+    "module": "es2020",
+    "moduleResolution": "node",
     "strict": true,
     "declaration": true,
-    "outDir": "./dist",
+    "outDir": "./dist-esm",
     "esModuleInterop": true,
     "lib": ["dom", "es2017"]
   },


### PR DESCRIPTION
# Motivation
Support both common js (cjs) and modules (mjs), to match the npm module "@dfinity/auth-client".  https://github.com/dfinity/agent-js/tree/main/packages/auth-client

# Changes
Add a tsconfig so that one provides cjs and the other mjs.