### PR TITLE
Add documentation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Built documentation
+/docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,9 @@
 {
   "name": "@dfinity/nns",
   "version": "0.1.5",
-  "license": "Apache-2.0",
   "lockfileVersion": 2,
   "requires": true,
+  "license": "Apache-2.0",
   "packages": {
     "": {
       "name": "@dfinity/nns",
@@ -30,6 +30,7 @@
         "text-encoding": "^0.7.0",
         "ts-jest": "^27.0.7",
         "ts-protoc-gen": "^0.15.0",
+        "typedoc": "^0.22.11",
         "typescript": "^4.5.2",
         "whatwg-fetch": "^3.6.2"
       }
@@ -4708,6 +4709,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4787,6 +4794,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4815,6 +4828,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -5508,6 +5533,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -6027,6 +6063,28 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.10",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.10.0"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
@@ -6106,6 +6164,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -9761,6 +9831,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9825,6 +9901,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9848,6 +9930,12 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "marked": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -10325,6 +10413,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -10716,6 +10815,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.10",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.10.0"
+      }
+    },
     "typescript": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
@@ -10778,6 +10890,18 @@
           "dev": true
         }
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
+    "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
     "update_proto": "bash ./scripts/update_proto.sh"
@@ -42,6 +43,7 @@
     "text-encoding": "^0.7.0",
     "ts-jest": "^27.0.7",
     "ts-protoc-gen": "^0.15.0",
+    "typedoc": "^0.22.11",
     "typescript": "^4.5.2",
     "whatwg-fetch": "^3.6.2"
   },


### PR DESCRIPTION
# Motivation
nns-js is destined to become a library for other projects to use.  A such the API needs to be accessible without perusing the implementation.

Creating documentation has two steps:
- Generating the docs
  - This is hopefully just a case of finding a suitable tool.
- Making the docs easily accessible
  - There is no common place where npm packages are documented.  Larger packages have homepages.
  - This PR does not address the question of publishing.

# Changes
- Adds [`typedoc`](https://typedoc.org/) as a dev dependency, and a script to generate the docs.

# Testing
I have generated the docs.  Some screenshots:
![Screenshot from 2022-01-18 12-27-26](https://user-images.githubusercontent.com/5982633/149929240-043e1fa1-4716-4cff-819d-15f4e14c9a60.png)
![Screenshot from 2022-01-18 12-26-25](https://user-images.githubusercontent.com/5982633/149929242-922049f0-e5eb-4cbc-829f-2a3efa405213.png)

