### PR TITLE
docs: license and repo on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@dfinity/nns",
   "version": "0.1.9",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
+  "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "rmdir": "node ./scripts/rmdir.mjs",
@@ -57,6 +58,13 @@
         "babelify"
       ]
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dfinity/nns-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dfinity/nns-js"
   },
   "keywords": [
     "internet computer",


### PR DESCRIPTION
# Motivation

Display missing GitHub link and license on [npm](https://www.npmjs.com/package/@dfinity/nns)

# Changes

- add `license` field to `package.json`
- add GitHub urls to `package.json`
- add license file to distributed files