### PR TITLE
Add tests to gh CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": [
     "dist/",
+    "candid/",
     "*.did.js",
     "*_pb.d.ts",
     "jest.config.js",

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,3 +54,16 @@ jobs:
         run: ./scripts/compile-idl-js
       - name: Verify that there are no changes to the compiled did files
         run: git diff --exit-code
+
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm run test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,17 @@ jobs:
       - name: Verify that there are no changes to the compiled did files
         run: git diff --exit-code
 
+  lint:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+
   test:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
# Motivation
We have few tests but as we write more, it would be good to run them in CI so that they always pass in main.

# Changes
- Added a github action to run tests.
- Added a github action to run lints, albeit ignoring candid and tests.