### PR TITLE
chore: exclude test from eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,8 @@
     "*.did.js",
     "*_pb.d.ts",
     "jest.config.js",
-    "test-setup.ts"
+    "test-setup.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
# Motivation

eslint is currently throwing an error when analyzing the tests. I think it might be ok to just exclude test from the linter

> /Users/dav...c/ledger.test.ts
>  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
> The file does not match your project config: src/ledger.test.ts.
> The file must be included in at least one of the projects provided

# Changes

- exclude `*.test.ts` and `*.spec.ts` from eslint analysis