### PR TITLE
Publish version 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation
We would like to publish.  The new listProposals() method would be useful for projects that depend on nns-js.

# Changes
Bumped the version number from 0.1.9 to 0.2.0 to take into account the API change from positional arguments to a dictionary.

# Tests
There are no code changes so no additional tests should be required.

# Next steps
Run: `npm publish`
Note: This is a normal release, not a nightly release.