### PR TITLE
Make build the prepare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
+    "prepare": "npm run build",
     "update_proto": "bash ./scripts/update_proto.sh"
   },
   "dependencies": {


### PR DESCRIPTION
# Motivation
Normally for an npm package I would expect to publish with:
- `npm ci`
- `npm publish`

Doing this in nns-js would publish an almost empty tarball, because `npm run build` has not been run.

To prevent accidents, it seems worth running `npm run build` automatically before publishing.  I have used `npm run prepare` but I note that there is a new script `prepublishOnly` that we could also use.  On balance I would choose `prepare` but am happy with either.

# Changes
- Add a  `prepare` script that runs npm build.

# Tests
- :
  - Prepared a blank new workspace
  - `npm ci`
  - `npm pack`
  - looked at the generated tarfile - it contained the expected files.