### PR TITLE
Publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
+    "proto",
     "README.md",
     "LICENSE"
   ],
@@ -20,6 +21,7 @@
     "doc": "typedoc ./src/index.ts",
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
+    "prepare": "npm run build",
     "update_proto": "bash ./scripts/update_proto.sh"
   },
   "dependencies": {


### PR DESCRIPTION
# Motivation
The publication of v0.2.0 has errors:
- The lock file is still versioned 0.1.9
- The proto files are not included in the package

# Changes
- Bump the package lock version
- Include proto files

# Tests
Not tested