### PR TITLE
Bump the lock file version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/agent": "^0.10.2",


### PR DESCRIPTION
# Motivation
The version number has been bumped in `package.json` but not `package-lock.json`.

# Changes
Make the version in `package-lock.json` match `package.json`

# Tests
None required