### PR TITLE
List neurons

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -56,7 +56,7 @@ export class RequestConverters {
     // this.principal = principal;
   }
 
-  public fromGetNeuron = (neuronIds?: NeuronId[]): RawListNeurons => {
+  public fromListNeurons = (neuronIds?: NeuronId[]): RawListNeurons => {
     return {
       neuron_ids: neuronIds ?? [],
       include_neurons_readable_by_caller: neuronIds ? false : true,

--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -8,6 +8,7 @@ import {
   Change as RawChange,
   Command as RawCommand,
   Followees as RawFollowees,
+  ListNeurons as RawListNeurons,
   ListProposalInfo,
   ManageNeuron as RawManageNeuron,
   NeuronId as RawNeuronId,
@@ -54,6 +55,13 @@ export class RequestConverters {
     // Needed only for protobuf.
     // this.principal = principal;
   }
+
+  public fromGetNeuron = (neuronIds?: NeuronId[]): RawListNeurons => {
+    return {
+      neuron_ids: neuronIds ?? [],
+      include_neurons_readable_by_caller: neuronIds ? false : true,
+    }
+  };
 
   public fromManageNeuron = (manageNeuron: ManageNeuron): RawManageNeuron => {
     return {

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -66,7 +66,6 @@ export class GovernanceCanister {
    * it is fetched using a query call.
    *
    * TODO: Decide: The library method is getNeurons but the raw method is list_neurons.  Do we want this inconsistency?
-   * Note: In the API, an empty list is treated as an absent list and returns all.  Treating no filter in the same way as an empty filter is typically error prone.  There was a spectacular example of this in a Google datacentre where a SRE intended to format the disks on one machine, however the command had a typo, so the matching expression matched no disks, no disks was treated as all disks and all the disks in the datacentre were formatted.  Hopefully we won't have any errors as bad as this, however the same pattern of treating empty as all is used here.
    */
   public getNeurons = async ({
     certified = true,

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -80,7 +80,7 @@ export class GovernanceCanister {
       // An anonymous caller has no neurons.
       return new Promise(() => []);
     }
-    let principal: Principal = this.myPrincipal;
+    const principal: Principal = this.myPrincipal;
     const rawRequest = this.requestConverters.fromListNeurons(neuronIds);
     const service = certified ? this.certifiedService : this.service;
     const raw_response = await service.list_neurons(rawRequest);

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -1,10 +1,13 @@
 import { Actor } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
 import { idlFactory as certifiedIdlFactory } from "../candid/governance.certified.idl";
 import { GovernanceService, idlFactory } from "../candid/governance.idl";
 import { RequestConverters } from "./canisters/governance/request.converters";
 import { ResponseConverters } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { GovernanceCanisterOptions } from "./types/governance";
+import { NeuronInfo } from "./types/governance_converters";
+import { NeuronId } from "./types/common";
 import {
   KnownNeuron,
   ListProposalsRequest,
@@ -17,12 +20,14 @@ export class GovernanceCanister {
     private readonly service: GovernanceService,
     private readonly certifiedService: GovernanceService,
     private readonly requestConverters: RequestConverters,
-    private readonly responseConverters: ResponseConverters
+    private readonly responseConverters: ResponseConverters,
+    private readonly myPrincipal?: Principal,
   ) {
     this.service = service;
     this.certifiedService = certifiedService;
     this.requestConverters = requestConverters;
     this.responseConverters = responseConverters;
+    this.myPrincipal = myPrincipal;
   }
 
   public static create(options: GovernanceCanisterOptions = {}) {
@@ -53,6 +58,33 @@ export class GovernanceCanister {
       responseConverters
     );
   }
+
+  /**
+   * Returns the list of neurons controlled by the caller.
+   *
+   * If `certified` is true, the request is fetched as an update call, otherwise
+   * it is fetched using a query call.
+   *
+   * TODO: Decide: The library method is getNeurons but the raw method is list_neurons.  Do we want this inconsistency?
+   * Note: In the API, an empty list is treated as an absent list and returns all.  Treating no filter in the same way as an empty filter is typically error prone.  There was a spectacular example of this in a Google datacentre where a SRE intended to format the disks on one machine, however the command had a typo, so the matching expression matched no disks, no disks was treated as all disks and all the disks in the datacentre were formatted.  Hopefully we won't have any errors as bad as this, however the same pattern of treating empty as all is used here.
+   */
+  public getNeurons = async ({
+    certified = true,
+    neuronIds,  // Presumably: Get all neurons owned by the caller OR get the intersection of this with the given list.
+  }: {
+    certified: boolean;
+    neuronIds?: NeuronId[]
+  }): Promise<NeuronInfo[]> => {
+    if (undefined === this.myPrincipal) {
+      // An anonymous caller has no neurons.
+      return new Promise(() => []);
+    }
+    let principal: Principal = this.myPrincipal;
+    const rawRequest = this.requestConverters.fromListNeurons(neuronIds);
+    const service = certified ? this.certifiedService : this.service;
+    const raw_response = await service.list_neurons(rawRequest);
+    return this.responseConverters.toArrayOfNeuronInfo(raw_response, principal);
+  };
 
   /**
    * Returns the list of neurons who have been approved by the community to

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -62,6 +62,8 @@ export class GovernanceCanister {
   /**
    * Returns the list of neurons controlled by the caller.
    *
+   * If an array of neuron IDs is provided, precisely those neurons will be fetched.
+   *
    * If `certified` is true, the request is fetched as an update call, otherwise
    * it is fetched using a query call.
    *
@@ -69,7 +71,7 @@ export class GovernanceCanister {
    */
   public getNeurons = async ({
     certified = true,
-    neuronIds, // Presumably: Get all neurons owned by the caller OR get the intersection of this with the given list.
+    neuronIds,
   }: {
     certified: boolean;
     neuronIds?: NeuronId[];


### PR DESCRIPTION
# Motivation
We need to list a user's neurons in the svelte nns dapp.

# Changes
Adds the `getNeurons()` method, that gets a caller's own neurons.  The method mirrors the `getNeurons` in `nns-dapp/frontend/ts` however I am a little concerned by the API and would be very open to exposing the same API as raw.

# Tests
Untested and unused.  The method may well be broken.  I am opening this PR so that the method is available before I have finished the createNeuron function, after which I plan to write tests for both.  The (very early and simple) test framework supports only anonymous calls so far and will have to be extended before this can get proper tests.
