### PR TITLE
Add getProposalInfo to governance

### DIFF
--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from "jest-mock-extended";
 import { GovernanceService } from "../candid/governance.idl";
-import { ListKnownNeuronsResponse } from "../candid/governanceTypes";
+import { ListKnownNeuronsResponse, ProposalInfo as RawProposalInfo } from "../candid/governanceTypes";
 import { GovernanceCanister } from "./governance";
 
 describe("GovernanceCanister.listKnownNeurons", () => {
@@ -77,4 +77,26 @@ describe("GovernanceCanister.listKnownNeurons", () => {
 
     expect(res.map((n) => Number(n.id))).toEqual([100, 200, 300, 400]);
   });
+
+  describe("getProposalInfo", () => {
+    it("should fetch and convert single ProposalInfo", async () => {
+      const service = mock<GovernanceService>();
+      const governance = GovernanceCanister.create({ certifiedServiceOverride: service, serviceOverride: service });
+      const rawProposal = {
+        id: [{ id: 1n }],
+        ballots: [],
+        proposal: [],
+        proposer: [],
+        latest_tally: [],
+      } as unknown as RawProposalInfo;
+      service.get_proposal_info.mockResolvedValue(Promise.resolve([rawProposal]));
+      const response = await governance.getProposalInfo({
+        proposalId: BigInt(1),
+      });
+
+      expect(service.get_proposal_info).toBeCalled();
+      expect(response).not.toBeUndefined();
+      expect(response).toHaveProperty('id', 1n);
+    });
+  })
 });

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -1,6 +1,9 @@
 import { mock } from "jest-mock-extended";
 import { GovernanceService } from "../candid/governance.idl";
-import { ListKnownNeuronsResponse, ProposalInfo as RawProposalInfo } from "../candid/governanceTypes";
+import {
+  ListKnownNeuronsResponse,
+  ProposalInfo as RawProposalInfo,
+} from "../candid/governanceTypes";
 import { GovernanceCanister } from "./governance";
 
 describe("GovernanceCanister.listKnownNeurons", () => {
@@ -81,7 +84,10 @@ describe("GovernanceCanister.listKnownNeurons", () => {
   describe("getProposalInfo", () => {
     it("should fetch and convert single ProposalInfo", async () => {
       const service = mock<GovernanceService>();
-      const governance = GovernanceCanister.create({ certifiedServiceOverride: service, serviceOverride: service });
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+        serviceOverride: service,
+      });
       const rawProposal = {
         id: [{ id: 1n }],
         ballots: [],
@@ -89,14 +95,16 @@ describe("GovernanceCanister.listKnownNeurons", () => {
         proposer: [],
         latest_tally: [],
       } as unknown as RawProposalInfo;
-      service.get_proposal_info.mockResolvedValue(Promise.resolve([rawProposal]));
+      service.get_proposal_info.mockResolvedValue(
+        Promise.resolve([rawProposal])
+      );
       const response = await governance.getProposalInfo({
         proposalId: BigInt(1),
       });
 
       expect(service.get_proposal_info).toBeCalled();
       expect(response).not.toBeUndefined();
-      expect(response).toHaveProperty('id', 1n);
+      expect(response).toHaveProperty("id", 1n);
     });
-  })
+  });
 });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -85,7 +85,9 @@ export class GovernanceCanister {
     }
     const principal: Principal = this.myPrincipal;
     const rawRequest = this.requestConverters.fromListNeurons(neuronIds);
-    const raw_response = await this.getGovernanceService(certified).list_neurons(rawRequest);
+    const raw_response = await this.getGovernanceService(
+      certified
+    ).list_neurons(rawRequest);
     return this.responseConverters.toArrayOfNeuronInfo(raw_response, principal);
   };
 
@@ -99,7 +101,9 @@ export class GovernanceCanister {
   public listKnownNeurons = async (
     certified = true
   ): Promise<KnownNeuron[]> => {
-    const response = await this.getGovernanceService(certified).list_known_neurons();
+    const response = await this.getGovernanceService(
+      certified
+    ).list_known_neurons();
 
     return response.known_neurons.map((n) => ({
       id: n.id[0]?.id ?? BigInt(0),
@@ -123,7 +127,9 @@ export class GovernanceCanister {
     certified?: boolean;
   }): Promise<ListProposalsResponse> => {
     const rawRequest = this.requestConverters.fromListProposalsRequest(request);
-    const rawResponse = await this.getGovernanceService(certified).list_proposals(rawRequest);
+    const rawResponse = await this.getGovernanceService(
+      certified
+    ).list_proposals(rawRequest);
     return this.responseConverters.toListProposalsResponse(rawResponse);
   };
 
@@ -140,9 +146,12 @@ export class GovernanceCanister {
     proposalId: bigint;
     certified?: boolean;
   }): Promise<ProposalInfo | undefined> => {
-    const [proposalInfo]: [] | [RawProposalInfo] = await this.getGovernanceService(certified).get_proposal_info(proposalId);
-    return proposalInfo ? this.responseConverters.toProposalInfo(proposalInfo) : undefined;
-  }
+    const [proposalInfo]: [] | [RawProposalInfo] =
+      await this.getGovernanceService(certified).get_proposal_info(proposalId);
+    return proposalInfo
+      ? this.responseConverters.toProposalInfo(proposalInfo)
+      : undefined;
+  };
 
   /**
    * Gets the NeuronID of a newly created neuron.

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -7,12 +7,12 @@ import { ResponseConverters } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { NeuronId } from "./types/common";
 import { GovernanceCanisterOptions } from "./types/governance";
-import { ProposalInfo } from "./types/governance_converters";
 import {
   KnownNeuron,
   ListProposalsRequest,
   ListProposalsResponse,
   NeuronInfo,
+  ProposalInfo,
 } from "./types/governance_converters";
 import { defaultAgent } from "./utils/agent.utils";
 
@@ -127,7 +127,7 @@ export class GovernanceCanister {
     const rawResponse = await service.list_proposals(rawRequest);
     return this.responseConverters.toListProposalsResponse(rawResponse);
   };
-  
+
   /**
    * Returns the proposal
    *
@@ -136,15 +136,15 @@ export class GovernanceCanister {
    */
   public getProposalInfo = async ({
     proposalId,
-    certified = true
+    certified = true,
   }: {
-    proposalId: bigint,
-    certified?: boolean
+    proposalId: bigint;
+    certified?: boolean;
   }): Promise<ProposalInfo | null> => {
     const service = certified ? this.certifiedService : this.service;
     const rawResponse = await service.get_proposal_info(proposalId);
     return rawResponse.length
       ? this.responseConverters.toProposalInfo(rawResponse[0])
       : null;
-  }
+  };
 }

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -2,6 +2,7 @@ import { Actor } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { idlFactory as certifiedIdlFactory } from "../candid/governance.certified.idl";
 import { GovernanceService, idlFactory } from "../candid/governance.idl";
+import { ProposalInfo as RawProposalInfo } from "../candid/governanceTypes";
 import { RequestConverters } from "./canisters/governance/request.converters";
 import { ResponseConverters } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
@@ -84,8 +85,7 @@ export class GovernanceCanister {
     }
     const principal: Principal = this.myPrincipal;
     const rawRequest = this.requestConverters.fromListNeurons(neuronIds);
-    const service = certified ? this.certifiedService : this.service;
-    const raw_response = await service.list_neurons(rawRequest);
+    const raw_response = await this.getGovernanceService(certified).list_neurons(rawRequest);
     return this.responseConverters.toArrayOfNeuronInfo(raw_response, principal);
   };
 
@@ -99,8 +99,7 @@ export class GovernanceCanister {
   public listKnownNeurons = async (
     certified = true
   ): Promise<KnownNeuron[]> => {
-    const service = certified ? this.certifiedService : this.service;
-    const response = await service.list_known_neurons();
+    const response = await this.getGovernanceService(certified).list_known_neurons();
 
     return response.known_neurons.map((n) => ({
       id: n.id[0]?.id ?? BigInt(0),
@@ -124,13 +123,12 @@ export class GovernanceCanister {
     certified?: boolean;
   }): Promise<ListProposalsResponse> => {
     const rawRequest = this.requestConverters.fromListProposalsRequest(request);
-    const service = certified ? this.certifiedService : this.service;
-    const rawResponse = await service.list_proposals(rawRequest);
+    const rawResponse = await this.getGovernanceService(certified).list_proposals(rawRequest);
     return this.responseConverters.toListProposalsResponse(rawResponse);
   };
 
   /**
-   * Returns the proposal
+   * Returns single proposal info
    *
    * If `certified` is true (default), the request is fetched as an update call, otherwise
    * it is fetched using a query call.
@@ -141,13 +139,10 @@ export class GovernanceCanister {
   }: {
     proposalId: bigint;
     certified?: boolean;
-  }): Promise<ProposalInfo | null> => {
-    const service = certified ? this.certifiedService : this.service;
-    const rawResponse = await service.get_proposal_info(proposalId);
-    return rawResponse.length
-      ? this.responseConverters.toProposalInfo(rawResponse[0])
-      : null;
-  };
+  }): Promise<ProposalInfo | undefined> => {
+    const [proposalInfo]: [] | [RawProposalInfo] = await this.getGovernanceService(certified).get_proposal_info(proposalId);
+    return proposalInfo ? this.responseConverters.toProposalInfo(proposalInfo) : undefined;
+  }
 
   /**
    * Gets the NeuronID of a newly created neuron.
@@ -172,4 +167,8 @@ export class GovernanceCanister {
       );
     }
   };
+
+  private getGovernanceService(certified: boolean): GovernanceService {
+    return certified ? this.certifiedService : this.service;
+  }
 }

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -7,6 +7,7 @@ import { ResponseConverters } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { NeuronId } from "./types/common";
 import { GovernanceCanisterOptions } from "./types/governance";
+import { ProposalInfo } from "./types/governance_converters";
 import {
   KnownNeuron,
   ListProposalsRequest,
@@ -126,4 +127,24 @@ export class GovernanceCanister {
     const rawResponse = await service.list_proposals(rawRequest);
     return this.responseConverters.toListProposalsResponse(rawResponse);
   };
+  
+  /**
+   * Returns the proposal
+   *
+   * If `certified` is true (default), the request is fetched as an update call, otherwise
+   * it is fetched using a query call.
+   */
+  public getProposalInfo = async ({
+    proposalId,
+    certified = true
+  }: {
+    proposalId: bigint,
+    certified?: boolean
+  }): Promise<ProposalInfo | null> => {
+    const service = certified ? this.certifiedService : this.service;
+    const rawResponse = await service.get_proposal_info(proposalId);
+    return rawResponse.length
+      ? this.responseConverters.toProposalInfo(rawResponse[0])
+      : null;
+  }
 }


### PR DESCRIPTION
# Motivation

Needs for ProposalDetails page. To fetch the proposal data by id provided in url.

# Changes

- `getProposalInfo()`

# Tests

🚧
