### PR TITLE
build: bump agent-js v0.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^0.10.2",
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/principal": "^0.10.2",
+        "@dfinity/agent": "^0.10.3",
+        "@dfinity/candid": "^0.10.3",
+        "@dfinity/principal": "^0.10.3",
         "crc": "^3.8.0",
         "crc-32": "^1.2.0",
         "google-protobuf": "^3.19.1",
@@ -512,9 +512,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
-      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.3.tgz",
+      "integrity": "sha512-trbTm8/o7N0yoIsNIMeKfbfKsqphDQ0Ql5cL5VdIUb57ClFKQg7VrQJoFXn9CYuhgqC7u5EnkNhlfLc2SH1Y3A==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -523,19 +523,19 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.10.2",
-        "@dfinity/principal": "^0.10.2"
+        "@dfinity/candid": "^0.10.3",
+        "@dfinity/principal": "^0.10.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
-      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.3.tgz",
+      "integrity": "sha512-+zhJGIlhPLsxh6ft2HPwKz6TQzkBIZHkOCgyrZ9ajvBWq1riyCEVlIgISlIiGfNcCWT4UjWZfe8s/2YIR2VqrQ=="
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
-      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.3.tgz",
+      "integrity": "sha512-32xwA+uSr3ieus55OG70b+wctiWxUJ5e/3JcmXgvC4o8TredAnfbQFuTqRi4AO+dh230hHqeRsKLoCvTdDRBXg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -8626,9 +8626,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.2.tgz",
-      "integrity": "sha512-ipzw+UYSUJWgwq5IM8PwHLXlfViFJWX+ZPvMD4vclDjwxiLf/nDZNk2sgLfYAi/2o2MpG6wUTUYriX/gmYrbkg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.10.3.tgz",
+      "integrity": "sha512-trbTm8/o7N0yoIsNIMeKfbfKsqphDQ0Ql5cL5VdIUb57ClFKQg7VrQJoFXn9CYuhgqC7u5EnkNhlfLc2SH1Y3A==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -8638,14 +8638,14 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.2.tgz",
-      "integrity": "sha512-vHRw6G5N6Nj8PlGl+Dx8pRGNCA/OQJ5v5ktj+t4ZL/4UIaebDZYzRZyrtBC0Vs1iG9BA5l48b7ByMH26UKLC6w=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.10.3.tgz",
+      "integrity": "sha512-+zhJGIlhPLsxh6ft2HPwKz6TQzkBIZHkOCgyrZ9ajvBWq1riyCEVlIgISlIiGfNcCWT4UjWZfe8s/2YIR2VqrQ=="
     },
     "@dfinity/principal": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.2.tgz",
-      "integrity": "sha512-CueU9ByIG2ifGDN8YnTPKbLJ6+ZDkoOLVmelaIcueTwqvHMIIvWNme76GwjbcbZ6/XgFd+I7cIKPMX0qQgbGCw=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.10.3.tgz",
+      "integrity": "sha512-32xwA+uSr3ieus55OG70b+wctiWxUJ5e/3JcmXgvC4o8TredAnfbQFuTqRi4AO+dh230hHqeRsKLoCvTdDRBXg=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "update_proto": "bash ./scripts/update_proto.sh"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.10.2",
-    "@dfinity/candid": "^0.10.2",
-    "@dfinity/principal": "^0.10.2",
+    "@dfinity/agent": "^0.10.3",
+    "@dfinity/candid": "^0.10.3",
+    "@dfinity/principal": "^0.10.3",
     "crc": "^3.8.0",
     "crc-32": "^1.2.0",
     "google-protobuf": "^3.19.1",


### PR DESCRIPTION
# Motivation

Bump agent-js to [v0.10.3](https://github.com/dfinity/agent-js/releases/tag/v0.10.3) with latest security improvements.

# Changes

- bump dfinity libs to v0.10.3

# Tests

I locally build and tested nns-js in nns-dapp svelte with the few features we have at the moment. All good.