### PR TITLE
Claim a neuron

### DIFF
--- a/src/governance.ts
+++ b/src/governance.ts
@@ -8,6 +8,7 @@ import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { NeuronId } from "./types/common";
 import { GovernanceCanisterOptions } from "./types/governance";
 import {
+  ClaimOrRefreshNeuronFromAccount,
   KnownNeuron,
   ListProposalsRequest,
   ListProposalsResponse,
@@ -125,5 +126,29 @@ export class GovernanceCanister {
     const service = certified ? this.certifiedService : this.service;
     const rawResponse = await service.list_proposals(rawRequest);
     return this.responseConverters.toListProposalsResponse(rawResponse);
+  };
+
+  /**
+   * Gets the NeuronID of a newly created neuron.
+   */
+  public claimOrRefreshNeuronFromAccount = async (
+    request: ClaimOrRefreshNeuronFromAccount
+  ): Promise<NeuronId> => {
+    // Note: This is an update call so the certified and uncertified services are identical in this case,
+    // however using the certified service provides protection in case that changes.
+    const service = this.certifiedService;
+    const response = await service.claim_or_refresh_neuron_from_account({
+      controller: request.controller ? [request.controller] : [],
+      memo: request.memo,
+    });
+
+    const result = response.result;
+    if (result.length && "NeuronId" in result[0]) {
+      return result[0].NeuronId.id;
+    } else {
+      throw new Error(
+        `Error claiming/refreshing neuron: ${JSON.stringify(result)}`
+      );
+    }
   };
 }


### PR DESCRIPTION
# Motivation
We wish to implement the `createNeuron()` function but not to include any nns-dapp code in nns-js.  This PR provides one required supporting function.

# Changes
- Add `claimOrRefreshNeuronFromAccount()` to the governance canister.

# Tests