### PR TITLE
refactor: drop governance converters stateless class for functions

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Principal } from "@dfinity/principal";
 import {
   AccountIdentifier as RawAccountIdentifier,
@@ -41,751 +40,723 @@ import {
   accountIdentifierToBytes,
   arrayBufferToArrayOfNumber,
 } from "../../utils/converter.utils";
-// Protobuf is not supported yet.
-// import { AccountIdentifier as PbAccountIdentifier } from "../../proto/ledger_pb";
-// import { ManageNeuron as PbManageNeuron } from "../../proto/governance_pb";
-// import {
-//   NeuronId as PbNeuronId,
-//   PrincipalId as PbPrincipalId,
-//   ProposalId as PbProposalId,
-// } from "../../proto/base_types_pb";
-export class RequestConverters {
-  private readonly principal?: Principal;
-  constructor() {
-    // Needed only for protobuf.
-    // this.principal = principal;
+
+const fromProposalId = (proposalId: ProposalId): RawNeuronId => ({
+  id: proposalId,
+});
+
+const fromNeuronId = (neuronId: NeuronId): RawNeuronId => ({
+  id: neuronId,
+});
+
+const fromFollowees = (followees: Array<NeuronId>): RawFollowees => ({
+  followees: followees.map(fromNeuronId),
+});
+
+const fromNeuronIdOrSubaccount = (
+  neuronIdOrSubaccount: NeuronIdOrSubaccount
+): RawNeuronIdOrSubaccount => {
+  if ("NeuronId" in neuronIdOrSubaccount) {
+    return { NeuronId: { id: neuronIdOrSubaccount.NeuronId } };
   }
+  if ("Subaccount" in neuronIdOrSubaccount) {
+    return { Subaccount: neuronIdOrSubaccount.Subaccount };
+  }
+  throw new UnsupportedValueError(neuronIdOrSubaccount);
+};
 
-  public fromListNeurons = (neuronIds?: NeuronId[]): RawListNeurons => {
+const fromAction = (action: Action): RawAction => {
+  if ("ExecuteNnsFunction" in action) {
+    const executeNnsFunction = action.ExecuteNnsFunction;
     return {
-      neuron_ids: neuronIds ?? [],
-      include_neurons_readable_by_caller: neuronIds ? false : true,
-    };
-  };
-
-  public fromManageNeuron = (manageNeuron: ManageNeuron): RawManageNeuron => {
-    return {
-      id: manageNeuron.id ? [this.fromNeuronId(manageNeuron.id)] : [],
-      command: manageNeuron.command
-        ? [this.fromCommand(manageNeuron.command)]
-        : [],
-      neuron_id_or_subaccount: manageNeuron.neuronIdOrSubaccount
-        ? [this.fromNeuronIdOrSubaccount(manageNeuron.neuronIdOrSubaccount)]
-        : [],
-    };
-  };
-
-  public fromClaimNeuronRequest = (
-    request: ClaimNeuronRequest
-  ): [Array<number>, bigint, bigint] => {
-    return [
-      arrayBufferToArrayOfNumber(request.publicKey),
-      request.nonce,
-      request.dissolveDelayInSecs,
-    ];
-  };
-
-  public fromListProposalsRequest = (
-    request: ListProposalsRequest
-  ): ListProposalInfo => {
-    return {
-      include_reward_status: request.includeRewardStatus,
-      before_proposal: request.beforeProposal
-        ? [this.fromProposalId(request.beforeProposal)]
-        : [],
-      limit: request.limit,
-      exclude_topic: request.excludeTopic,
-      include_status: request.includeStatus,
-    };
-  };
-
-  /* Protobuf is not supported yet
-  public fromAddHotKeyRequest = (request: AddHotKeyRequest): PbManageNeuron => {
-    const hotkeyPrincipal = new PbPrincipalId();
-    hotkeyPrincipal.setSerializedId(
-      Principal.fromText(request.principal).toUint8Array()
-    );
-
-    const hotkey = new PbManageNeuron.AddHotKey();
-    hotkey.setNewHotKey(hotkeyPrincipal);
-
-    const configure = new PbManageNeuron.Configure();
-    configure.setAddHotKey(hotkey);
-
-    const result = new PbManageNeuron();
-    result.setConfigure(configure);
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    result.setNeuronId(neuronId);
-
-    return result;
-  };
-  */
-
-  public fromClaimOrRefreshNeuronRequest = (
-    request: ClaimOrRefreshNeuronRequest
-  ): RawManageNeuron => {
-    const rawCommand: RawCommand = {
-      ClaimOrRefresh: { by: [{ NeuronIdOrSubaccount: {} }] },
-    };
-    return {
-      id: [],
-      command: [rawCommand],
-      neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
-    };
-  };
-
-  /* Protobuf is not supported yet
-  public fromMergeMaturityRequest = (
-    request: MergeMaturityRequest
-  ): PbManageNeuron => {
-    const mergeMaturity = new PbManageNeuron.MergeMaturity();
-    mergeMaturity.setPercentageToMerge(request.percentageToMerge);
-    const manageNeuron = new PbManageNeuron();
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    manageNeuron.setNeuronId(neuronId);
-    manageNeuron.setMergeMaturity(mergeMaturity);
-    return manageNeuron;
-  };
-  */
-
-  /* Protobuf is not supported yet
-  public fromRemoveHotKeyRequest = (
-    request: RemoveHotKeyRequest
-  ): PbManageNeuron => {
-    const hotkeyPrincipal = new PbPrincipalId();
-    hotkeyPrincipal.setSerializedId(
-      Principal.fromText(request.principal).toUint8Array()
-    );
-
-    const command = new PbManageNeuron.RemoveHotKey();
-    command.setHotKeyToRemove(hotkeyPrincipal);
-
-    const configure = new PbManageNeuron.Configure();
-    configure.setRemoveHotKey(command);
-
-    const result = new PbManageNeuron();
-    result.setConfigure(configure);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    result.setNeuronId(neuronId);
-
-    return result;
-  };
-
-  public fromStartDissolvingRequest = (
-    request: StartDissolvingRequest
-  ): PbManageNeuron => {
-    const configure = new PbManageNeuron.Configure();
-    configure.setStartDissolving(new PbManageNeuron.StartDissolving());
-
-    const result = new PbManageNeuron();
-    result.setConfigure(configure);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    result.setNeuronId(neuronId);
-
-    return result;
-  };
-
-  public fromStopDissolvingRequest = (
-    request: StopDissolvingRequest
-  ): PbManageNeuron => {
-    const configure = new PbManageNeuron.Configure();
-    configure.setStopDissolving(new PbManageNeuron.StopDissolving());
-
-    const result = new PbManageNeuron();
-    result.setConfigure(configure);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    result.setNeuronId(neuronId);
-
-    return result;
-  };
-
-  public fromIncreaseDissolveDelayRequest = (
-    request: IncreaseDissolveDelayRequest
-  ): PbManageNeuron => {
-    const command = new PbManageNeuron.IncreaseDissolveDelay();
-    command.setAdditionalDissolveDelaySeconds(
-      request.additionalDissolveDelaySeconds
-    );
-
-    const configure = new PbManageNeuron.Configure();
-    configure.setIncreaseDissolveDelay(command);
-
-    const result = new PbManageNeuron();
-    result.setConfigure(configure);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    result.setNeuronId(neuronId);
-
-    return result;
-  };
-
-  public fromFollowRequest = (request: FollowRequest): PbManageNeuron => {
-    const follow = new PbManageNeuron.Follow();
-    follow.setTopic(request.topic);
-    follow.setFolloweesList(
-      request.followees.map((followee) => {
-        const neuronId = new PbNeuronId();
-        neuronId.setId(followee.toString());
-        return neuronId;
-      })
-    );
-    const manageNeuron = new PbManageNeuron();
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    manageNeuron.setNeuronId(neuronId);
-    manageNeuron.setFollow(follow);
-    return manageNeuron;
-  };
-
-  public fromRegisterVoteRequest = (
-    request: RegisterVoteRequest
-  ): PbManageNeuron => {
-    const registerVote = new PbManageNeuron.RegisterVote();
-    registerVote.setVote(request.vote);
-    const proposal = new PbProposalId();
-    proposal.setId(request.proposal.toString());
-    registerVote.setProposal(proposal);
-    const manageNeuron = new PbManageNeuron();
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    manageNeuron.setNeuronId(neuronId);
-    manageNeuron.setRegisterVote(registerVote);
-    return manageNeuron;
-  };
-
-  public fromSpawnRequest = (request: SpawnRequest): PbManageNeuron => {
-    const spawn = new PbManageNeuron.Spawn();
-
-    if (request.newController) {
-      const newController = new PbPrincipalId();
-      newController.setSerializedId(
-        Principal.fromText(request.newController).toUint8Array().slice(4)
-      );
-      spawn.setNewController(newController);
-    }
-
-    const manageNeuron = new PbManageNeuron();
-    manageNeuron.setSpawn(spawn);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    manageNeuron.setNeuronId(neuronId);
-    return manageNeuron;
-  };
-  */
-
-  public fromSplitRequest = (request: SplitRequest): RawManageNeuron => {
-    const rawCommand: RawCommand = {
-      Split: {
-        amount_e8s: request.amount,
+      ExecuteNnsFunction: {
+        nns_function: executeNnsFunction.nnsFunctionId,
+        payload: arrayBufferToArrayOfNumber(executeNnsFunction.payloadBytes),
       },
-    };
-    return {
-      id: [],
-      command: [rawCommand],
-      neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
-    };
-  };
-
-  /* Protobuf is not supported yet
-  public fromDisburseRequest = (request: DisburseRequest): PbManageNeuron => {
-    const disburse = new PbManageNeuron.Disburse();
-
-    if (request.toAccountId) {
-      const toAccountIdentifier = new PbAccountIdentifier();
-      toAccountIdentifier.setHash(
-        Uint8Array.from(Buffer.from(request.toAccountId, "hex"))
-      );
-      disburse.setToAccount(toAccountIdentifier);
-    }
-
-    if (request.amount != null) {
-      const amount = new PbManageNeuron.Disburse.Amount();
-      amount.setE8s(request.amount.toString());
-      disburse.setAmount(amount);
-    }
-
-    const manageNeuron = new PbManageNeuron();
-    manageNeuron.setDisburse(disburse);
-
-    const neuronId = new PbNeuronId();
-    neuronId.setId(request.neuronId.toString());
-    manageNeuron.setNeuronId(neuronId);
-    return manageNeuron;
-  };
-  */
-
-  public fromDisburseToNeuronRequest = (
-    request: DisburseToNeuronRequest
-  ): RawManageNeuron => {
-    const rawCommand: RawCommand = {
-      DisburseToNeuron: {
-        dissolve_delay_seconds: request.dissolveDelaySeconds,
-        kyc_verified: request.kycVerified,
-        amount_e8s: request.amount,
-        new_controller:
-          request.newController != null
-            ? [Principal.fromText(request.newController)]
-            : [],
-        nonce: request.nonce,
-      },
-    };
-    return {
-      id: [],
-      command: [rawCommand],
-      neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
-    };
-  };
-
-  public fromMakeProposalRequest = (
-    request: MakeProposalRequest
-  ): RawManageNeuron => {
-    const rawCommand: RawCommand = {
-      MakeProposal: {
-        url: request.url,
-        title: request.title != null ? [request.title] : [],
-        summary: request.summary,
-        action: [this.fromAction(request.action)],
-      },
-    };
-    return {
-      id: [],
-      command: [rawCommand],
-      neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
-    };
-  };
-
-  private fromFollowees(followees: Array<NeuronId>): RawFollowees {
-    return {
-      followees: followees.map(this.fromNeuronId),
     };
   }
-
-  private fromNeuronId = (neuronId: NeuronId): RawNeuronId => {
+  if ("ManageNeuron" in action) {
+    const manageNeuron = action.ManageNeuron;
     return {
-      id: neuronId,
+      ManageNeuron: fromManageNeuron(manageNeuron),
     };
-  };
-
-  private fromNeuronIdOrSubaccount = (
-    neuronIdOrSubaccount: NeuronIdOrSubaccount
-  ): RawNeuronIdOrSubaccount => {
-    if ("NeuronId" in neuronIdOrSubaccount) {
-      return { NeuronId: { id: neuronIdOrSubaccount.NeuronId } };
-    }
-    if ("Subaccount" in neuronIdOrSubaccount) {
-      return { Subaccount: neuronIdOrSubaccount.Subaccount };
-    }
-    throw new UnsupportedValueError(neuronIdOrSubaccount);
-  };
-
-  private fromProposalId = (proposalId: ProposalId): RawNeuronId => {
+  }
+  if ("ApproveGenesisKyc" in action) {
+    const approveGenesisKyc = action.ApproveGenesisKyc;
     return {
-      id: proposalId,
+      ApproveGenesisKyc: {
+        principals: approveGenesisKyc.principals.map(Principal.fromText),
+      },
     };
-  };
-
-  private fromAction = (action: Action): RawAction => {
-    if ("ExecuteNnsFunction" in action) {
-      const executeNnsFunction = action.ExecuteNnsFunction;
-      return {
-        ExecuteNnsFunction: {
-          nns_function: executeNnsFunction.nnsFunctionId,
-          payload: arrayBufferToArrayOfNumber(executeNnsFunction.payloadBytes),
-        },
-      };
-    }
-    if ("ManageNeuron" in action) {
-      const manageNeuron = action.ManageNeuron;
-      return {
-        ManageNeuron: this.fromManageNeuron(manageNeuron),
-      };
-    }
-    if ("ApproveGenesisKyc" in action) {
-      const approveGenesisKyc = action.ApproveGenesisKyc;
-      return {
-        ApproveGenesisKyc: {
-          principals: approveGenesisKyc.principals.map(Principal.fromText),
-        },
-      };
-    }
-    if ("ManageNetworkEconomics" in action) {
-      const networkEconomics = action.ManageNetworkEconomics;
-      return {
-        ManageNetworkEconomics: {
-          neuron_minimum_stake_e8s: networkEconomics.neuronMinimumStake,
-          max_proposals_to_keep_per_topic:
-            networkEconomics.maxProposalsToKeepPerTopic,
-          neuron_management_fee_per_proposal_e8s:
-            networkEconomics.neuronManagementFeePerProposal,
-          reject_cost_e8s: networkEconomics.rejectCost,
-          transaction_fee_e8s: networkEconomics.transactionFee,
-          neuron_spawn_dissolve_delay_seconds:
-            networkEconomics.neuronSpawnDissolveDelaySeconds,
-          minimum_icp_xdr_rate: networkEconomics.minimumIcpXdrRate,
-          maximum_node_provider_rewards_e8s:
-            networkEconomics.maximumNodeProviderRewards,
-        },
-      };
-    }
-    if ("RewardNodeProvider" in action) {
-      const rewardNodeProvider = action.RewardNodeProvider;
-      return {
-        RewardNodeProvider: {
-          node_provider: rewardNodeProvider.nodeProvider
-            ? [this.fromNodeProvider(rewardNodeProvider.nodeProvider)]
-            : [],
-          amount_e8s: rewardNodeProvider.amountE8s,
-          reward_mode:
-            rewardNodeProvider.rewardMode != null
-              ? [this.fromRewardMode(rewardNodeProvider.rewardMode)]
-              : [],
-        },
-      };
-    }
-    if ("RewardNodeProviders" in action) {
-      const rewardNodeProviders = action.RewardNodeProviders;
-      return {
-        RewardNodeProviders: {
-          rewards: rewardNodeProviders.rewards.map((r) => ({
-            node_provider: r.nodeProvider
-              ? [this.fromNodeProvider(r.nodeProvider)]
-              : [],
-            amount_e8s: r.amountE8s,
-            reward_mode:
-              r.rewardMode != null ? [this.fromRewardMode(r.rewardMode)] : [],
-          })),
-        },
-      };
-    }
-    if ("AddOrRemoveNodeProvider" in action) {
-      const addOrRemoveNodeProvider = action.AddOrRemoveNodeProvider;
-      return {
-        AddOrRemoveNodeProvider: {
-          change: addOrRemoveNodeProvider.change
-            ? [this.fromChange(addOrRemoveNodeProvider.change)]
-            : [],
-        },
-      };
-    }
-    if ("Motion" in action) {
-      const motion = action.Motion;
-      return {
-        Motion: {
-          motion_text: motion.motionText,
-        },
-      };
-    }
-
-    if ("SetDefaultFollowees" in action) {
-      const setDefaultFollowees = action.SetDefaultFollowees;
-      return {
-        SetDefaultFollowees: {
-          default_followees: setDefaultFollowees.defaultFollowees.map((f) => [
-            f.topic as number,
-            this.fromFollowees(f.followees),
-          ]),
-        },
-      };
-    }
-
-    if ("RegisterKnownNeuron" in action) {
-      const knownNeuron = action.RegisterKnownNeuron;
-      return {
-        RegisterKnownNeuron: {
-          id: [{ id: knownNeuron.id }],
-          known_neuron_data: [
-            {
-              name: knownNeuron.name,
-              description:
-                knownNeuron.description !== undefined
-                  ? [knownNeuron.description]
-                  : [],
-            },
-          ],
-        },
-      };
-    }
-
-    // If there's a missing action, this line will cause a compiler error.
-    throw new UnsupportedValueError(action);
-  };
-
-  private fromCommand = (command: Command): RawCommand => {
-    if ("Split" in command) {
-      const split = command.Split;
-      return {
-        Split: {
-          amount_e8s: split.amount,
-        },
-      };
-    }
-    if ("Follow" in command) {
-      const follow = command.Follow;
-      return {
-        Follow: {
-          topic: follow.topic,
-          followees: follow.followees.map(this.fromNeuronId),
-        },
-      };
-    }
-    if ("ClaimOrRefresh" in command) {
-      const claimOrRefresh = command.ClaimOrRefresh;
-      return {
-        ClaimOrRefresh: {
-          by: claimOrRefresh.by
-            ? [this.fromClaimOrRefreshBy(claimOrRefresh.by)]
-            : [],
-        },
-      };
-    }
-    if ("Configure" in command) {
-      const configure = command.Configure;
-      return {
-        Configure: {
-          operation: configure.operation
-            ? [this.fromOperation(configure.operation)]
-            : [],
-        },
-      };
-    }
-    if ("RegisterVote" in command) {
-      const registerVote = command.RegisterVote;
-      return {
-        RegisterVote: {
-          vote: registerVote.vote,
-          proposal: registerVote.proposal
-            ? [this.fromProposalId(registerVote.proposal)]
-            : [],
-        },
-      };
-    }
-    if ("DisburseToNeuron" in command) {
-      const disburseToNeuron = command.DisburseToNeuron;
-      return {
-        DisburseToNeuron: {
-          dissolve_delay_seconds: disburseToNeuron.dissolveDelaySeconds,
-          kyc_verified: disburseToNeuron.kycVerified,
-          amount_e8s: disburseToNeuron.amount,
-          new_controller: disburseToNeuron.newController
-            ? [Principal.fromText(disburseToNeuron.newController)]
-            : [],
-          nonce: disburseToNeuron.nonce,
-        },
-      };
-    }
-    if ("MergeMaturity" in command) {
-      const mergeMaturity = command.MergeMaturity;
-      return {
-        MergeMaturity: {
-          percentage_to_merge: mergeMaturity.percentageToMerge,
-        },
-      };
-    }
-    if ("MakeProposal" in command) {
-      const makeProposal = command.MakeProposal;
-      return {
-        MakeProposal: {
-          url: makeProposal.url,
-          title: [],
-          action: makeProposal.action
-            ? [this.fromAction(makeProposal.action)]
-            : [],
-          summary: makeProposal.summary,
-        },
-      };
-    }
-    if ("Disburse" in command) {
-      const disburse = command.Disburse;
-      return {
-        Disburse: {
-          to_account: disburse.toAccountId
-            ? [this.fromAccountIdentifier(disburse.toAccountId)]
-            : [],
-          amount: disburse.amount ? [this.fromAmount(disburse.amount)] : [],
-        },
-      };
-    }
-    if ("Spawn" in command) {
-      const spawn = command.Spawn;
-      return {
-        Spawn: {
-          new_controller: spawn.newController
-            ? [Principal.fromText(spawn.newController)]
-            : [],
-          nonce: [],
-        },
-      };
-    }
-    if ("Merge" in command) {
-      const merge = command.Merge;
-      return {
-        Merge: {
-          source_neuron_id: merge.sourceNeuronId
-            ? [{ id: merge.sourceNeuronId }]
-            : [],
-        },
-      };
-    }
-
-    // If there's a missing command above, this line will cause a compiler error.
-    throw new UnsupportedValueError(command);
-  };
-
-  private fromOperation = (operation: Operation): RawOperation => {
-    if ("RemoveHotKey" in operation) {
-      const removeHotKey = operation.RemoveHotKey;
-      return {
-        RemoveHotKey: {
-          hot_key_to_remove:
-            removeHotKey.hotKeyToRemove != null
-              ? [Principal.fromText(removeHotKey.hotKeyToRemove)]
-              : [],
-        },
-      };
-    }
-    if ("AddHotKey" in operation) {
-      const addHotKey = operation.AddHotKey;
-      return {
-        AddHotKey: {
-          new_hot_key: addHotKey.newHotKey
-            ? [Principal.fromText(addHotKey.newHotKey)]
-            : [],
-        },
-      };
-    }
-    if ("StopDissolving" in operation) {
-      return {
-        StopDissolving: {},
-      };
-    }
-    if ("StartDissolving" in operation) {
-      return {
-        StartDissolving: {},
-      };
-    }
-    if ("IncreaseDissolveDelay" in operation) {
-      const increaseDissolveDelay = operation.IncreaseDissolveDelay;
-      return {
-        IncreaseDissolveDelay: {
-          additional_dissolve_delay_seconds:
-            increaseDissolveDelay.additionalDissolveDelaySeconds,
-        },
-      };
-    }
-    if ("JoinCommunityFund" in operation) {
-      return operation;
-    }
-    if ("SetDissolveTimestamp" in operation) {
-      const setDissolveTimestamp = operation.SetDissolveTimestamp;
-      return {
-        SetDissolveTimestamp: {
-          dissolve_timestamp_seconds:
-            setDissolveTimestamp.dissolveTimestampSeconds,
-        },
-      };
-    }
-    // If there's a missing operation above, this line will cause a compiler error.
-    throw new UnsupportedValueError(operation);
-  };
-
-  private fromChange = (change: Change): RawChange => {
-    if ("ToRemove" in change) {
-      return {
-        ToRemove: this.fromNodeProvider(change.ToRemove),
-      };
-    }
-    if ("ToAdd" in change) {
-      return {
-        ToAdd: this.fromNodeProvider(change.ToAdd),
-      };
-    }
-    // If there's a missing change above, this line will cause a compiler error.
-    throw new UnsupportedValueError(change);
-  };
-
-  private fromNodeProvider = (nodeProvider: NodeProvider): RawNodeProvider => {
+  }
+  if ("ManageNetworkEconomics" in action) {
+    const networkEconomics = action.ManageNetworkEconomics;
     return {
-      id: nodeProvider.id != null ? [Principal.fromText(nodeProvider.id)] : [],
-      reward_account:
-        nodeProvider.rewardAccount != null
-          ? [this.fromAccountIdentifier(nodeProvider.rewardAccount)]
+      ManageNetworkEconomics: {
+        neuron_minimum_stake_e8s: networkEconomics.neuronMinimumStake,
+        max_proposals_to_keep_per_topic:
+          networkEconomics.maxProposalsToKeepPerTopic,
+        neuron_management_fee_per_proposal_e8s:
+          networkEconomics.neuronManagementFeePerProposal,
+        reject_cost_e8s: networkEconomics.rejectCost,
+        transaction_fee_e8s: networkEconomics.transactionFee,
+        neuron_spawn_dissolve_delay_seconds:
+          networkEconomics.neuronSpawnDissolveDelaySeconds,
+        minimum_icp_xdr_rate: networkEconomics.minimumIcpXdrRate,
+        maximum_node_provider_rewards_e8s:
+          networkEconomics.maximumNodeProviderRewards,
+      },
+    };
+  }
+  if ("RewardNodeProvider" in action) {
+    const rewardNodeProvider = action.RewardNodeProvider;
+    return {
+      RewardNodeProvider: {
+        node_provider: rewardNodeProvider.nodeProvider
+          ? [fromNodeProvider(rewardNodeProvider.nodeProvider)]
           : [],
+        amount_e8s: rewardNodeProvider.amountE8s,
+        reward_mode:
+          rewardNodeProvider.rewardMode != null
+            ? [fromRewardMode(rewardNodeProvider.rewardMode)]
+            : [],
+      },
     };
+  }
+  if ("RewardNodeProviders" in action) {
+    const rewardNodeProviders = action.RewardNodeProviders;
+    return {
+      RewardNodeProviders: {
+        rewards: rewardNodeProviders.rewards.map((r) => ({
+          node_provider: r.nodeProvider
+            ? [fromNodeProvider(r.nodeProvider)]
+            : [],
+          amount_e8s: r.amountE8s,
+          reward_mode:
+            r.rewardMode != null ? [fromRewardMode(r.rewardMode)] : [],
+        })),
+      },
+    };
+  }
+  if ("AddOrRemoveNodeProvider" in action) {
+    const addOrRemoveNodeProvider = action.AddOrRemoveNodeProvider;
+    return {
+      AddOrRemoveNodeProvider: {
+        change: addOrRemoveNodeProvider.change
+          ? [fromChange(addOrRemoveNodeProvider.change)]
+          : [],
+      },
+    };
+  }
+  if ("Motion" in action) {
+    const motion = action.Motion;
+    return {
+      Motion: {
+        motion_text: motion.motionText,
+      },
+    };
+  }
+
+  if ("SetDefaultFollowees" in action) {
+    const setDefaultFollowees = action.SetDefaultFollowees;
+    return {
+      SetDefaultFollowees: {
+        default_followees: setDefaultFollowees.defaultFollowees.map((f) => [
+          f.topic as number,
+          fromFollowees(f.followees),
+        ]),
+      },
+    };
+  }
+
+  if ("RegisterKnownNeuron" in action) {
+    const knownNeuron = action.RegisterKnownNeuron;
+    return {
+      RegisterKnownNeuron: {
+        id: [{ id: knownNeuron.id }],
+        known_neuron_data: [
+          {
+            name: knownNeuron.name,
+            description:
+              knownNeuron.description !== undefined
+                ? [knownNeuron.description]
+                : [],
+          },
+        ],
+      },
+    };
+  }
+
+  // If there's a missing action, this line will cause a compiler error.
+  throw new UnsupportedValueError(action);
+};
+
+const fromCommand = (command: Command): RawCommand => {
+  if ("Split" in command) {
+    const split = command.Split;
+    return {
+      Split: {
+        amount_e8s: split.amount,
+      },
+    };
+  }
+  if ("Follow" in command) {
+    const follow = command.Follow;
+    return {
+      Follow: {
+        topic: follow.topic,
+        followees: follow.followees.map(fromNeuronId),
+      },
+    };
+  }
+  if ("ClaimOrRefresh" in command) {
+    const claimOrRefresh = command.ClaimOrRefresh;
+    return {
+      ClaimOrRefresh: {
+        by: claimOrRefresh.by ? [fromClaimOrRefreshBy(claimOrRefresh.by)] : [],
+      },
+    };
+  }
+  if ("Configure" in command) {
+    const configure = command.Configure;
+    return {
+      Configure: {
+        operation: configure.operation
+          ? [fromOperation(configure.operation)]
+          : [],
+      },
+    };
+  }
+  if ("RegisterVote" in command) {
+    const registerVote = command.RegisterVote;
+    return {
+      RegisterVote: {
+        vote: registerVote.vote,
+        proposal: registerVote.proposal
+          ? [fromProposalId(registerVote.proposal)]
+          : [],
+      },
+    };
+  }
+  if ("DisburseToNeuron" in command) {
+    const disburseToNeuron = command.DisburseToNeuron;
+    return {
+      DisburseToNeuron: {
+        dissolve_delay_seconds: disburseToNeuron.dissolveDelaySeconds,
+        kyc_verified: disburseToNeuron.kycVerified,
+        amount_e8s: disburseToNeuron.amount,
+        new_controller: disburseToNeuron.newController
+          ? [Principal.fromText(disburseToNeuron.newController)]
+          : [],
+        nonce: disburseToNeuron.nonce,
+      },
+    };
+  }
+  if ("MergeMaturity" in command) {
+    const mergeMaturity = command.MergeMaturity;
+    return {
+      MergeMaturity: {
+        percentage_to_merge: mergeMaturity.percentageToMerge,
+      },
+    };
+  }
+  if ("MakeProposal" in command) {
+    const makeProposal = command.MakeProposal;
+    return {
+      MakeProposal: {
+        url: makeProposal.url,
+        title: [],
+        action: makeProposal.action ? [fromAction(makeProposal.action)] : [],
+        summary: makeProposal.summary,
+      },
+    };
+  }
+  if ("Disburse" in command) {
+    const disburse = command.Disburse;
+    return {
+      Disburse: {
+        to_account: disburse.toAccountId
+          ? [fromAccountIdentifier(disburse.toAccountId)]
+          : [],
+        amount: disburse.amount ? [fromAmount(disburse.amount)] : [],
+      },
+    };
+  }
+  if ("Spawn" in command) {
+    const spawn = command.Spawn;
+    return {
+      Spawn: {
+        new_controller: spawn.newController
+          ? [Principal.fromText(spawn.newController)]
+          : [],
+        nonce: [],
+      },
+    };
+  }
+  if ("Merge" in command) {
+    const merge = command.Merge;
+    return {
+      Merge: {
+        source_neuron_id: merge.sourceNeuronId
+          ? [{ id: merge.sourceNeuronId }]
+          : [],
+      },
+    };
+  }
+
+  // If there's a missing command above, this line will cause a compiler error.
+  throw new UnsupportedValueError(command);
+};
+
+const fromOperation = (operation: Operation): RawOperation => {
+  if ("RemoveHotKey" in operation) {
+    const removeHotKey = operation.RemoveHotKey;
+    return {
+      RemoveHotKey: {
+        hot_key_to_remove:
+          removeHotKey.hotKeyToRemove != null
+            ? [Principal.fromText(removeHotKey.hotKeyToRemove)]
+            : [],
+      },
+    };
+  }
+  if ("AddHotKey" in operation) {
+    const addHotKey = operation.AddHotKey;
+    return {
+      AddHotKey: {
+        new_hot_key: addHotKey.newHotKey
+          ? [Principal.fromText(addHotKey.newHotKey)]
+          : [],
+      },
+    };
+  }
+  if ("StopDissolving" in operation) {
+    return {
+      StopDissolving: {},
+    };
+  }
+  if ("StartDissolving" in operation) {
+    return {
+      StartDissolving: {},
+    };
+  }
+  if ("IncreaseDissolveDelay" in operation) {
+    const increaseDissolveDelay = operation.IncreaseDissolveDelay;
+    return {
+      IncreaseDissolveDelay: {
+        additional_dissolve_delay_seconds:
+          increaseDissolveDelay.additionalDissolveDelaySeconds,
+      },
+    };
+  }
+  if ("JoinCommunityFund" in operation) {
+    return operation;
+  }
+  if ("SetDissolveTimestamp" in operation) {
+    const setDissolveTimestamp = operation.SetDissolveTimestamp;
+    return {
+      SetDissolveTimestamp: {
+        dissolve_timestamp_seconds:
+          setDissolveTimestamp.dissolveTimestampSeconds,
+      },
+    };
+  }
+  // If there's a missing operation above, this line will cause a compiler error.
+  throw new UnsupportedValueError(operation);
+};
+
+const fromChange = (change: Change): RawChange => {
+  if ("ToRemove" in change) {
+    return {
+      ToRemove: fromNodeProvider(change.ToRemove),
+    };
+  }
+  if ("ToAdd" in change) {
+    return {
+      ToAdd: fromNodeProvider(change.ToAdd),
+    };
+  }
+  // If there's a missing change above, this line will cause a compiler error.
+  throw new UnsupportedValueError(change);
+};
+
+const fromNodeProvider = (nodeProvider: NodeProvider): RawNodeProvider => {
+  return {
+    id: nodeProvider.id != null ? [Principal.fromText(nodeProvider.id)] : [],
+    reward_account:
+      nodeProvider.rewardAccount != null
+        ? [fromAccountIdentifier(nodeProvider.rewardAccount)]
+        : [],
+  };
+};
+
+const fromAmount = (amount: E8s): Amount => ({
+  e8s: amount,
+});
+
+const fromAccountIdentifier = (
+  accountIdentifier: AccountIdentifier
+): RawAccountIdentifier => {
+  const bytes: Uint8Array = accountIdentifierToBytes(accountIdentifier);
+  return {
+    hash: arrayBufferToArrayOfNumber(bytes),
+  };
+};
+
+const fromRewardMode = (rewardMode: RewardMode): RawRewardMode => {
+  if ("RewardToNeuron" in rewardMode) {
+    return {
+      RewardToNeuron: {
+        dissolve_delay_seconds: rewardMode.RewardToNeuron.dissolveDelaySeconds,
+      },
+    };
+  } else if ("RewardToAccount" in rewardMode) {
+    return {
+      RewardToAccount: {
+        to_account:
+          rewardMode.RewardToAccount.toAccount != null
+            ? [fromAccountIdentifier(rewardMode.RewardToAccount.toAccount)]
+            : [],
+      },
+    };
+  } else {
+    // If there's a missing rewardMode above, this line will cause a compiler error.
+    throw new UnsupportedValueError(rewardMode);
+  }
+};
+
+const fromClaimOrRefreshBy = (by: By): RawBy => {
+  if ("NeuronIdOrSubaccount" in by) {
+    return {
+      NeuronIdOrSubaccount: {},
+    };
+  } else if ("Memo" in by) {
+    return {
+      Memo: by.Memo,
+    };
+  } else if ("MemoAndController" in by) {
+    return {
+      MemoAndController: {
+        memo: by.MemoAndController.memo,
+        controller: by.MemoAndController.controller
+          ? [by.MemoAndController.controller]
+          : [],
+      },
+    };
+  } else {
+    // Ensures all cases are covered at compile-time.
+    throw new UnsupportedValueError(by);
+  }
+};
+
+export const fromListNeurons = (neuronIds?: NeuronId[]): RawListNeurons => ({
+  neuron_ids: neuronIds ?? [],
+  include_neurons_readable_by_caller: neuronIds ? false : true,
+});
+
+export const fromManageNeuron = ({
+  id,
+  command,
+  neuronIdOrSubaccount,
+}: ManageNeuron): RawManageNeuron => ({
+  id: id ? [fromNeuronId(id)] : [],
+  command: command ? [fromCommand(command)] : [],
+  neuron_id_or_subaccount: neuronIdOrSubaccount
+    ? [fromNeuronIdOrSubaccount(neuronIdOrSubaccount)]
+    : [],
+});
+
+export const fromClaimNeuronRequest = ({
+  publicKey,
+  nonce,
+  dissolveDelayInSecs,
+}: ClaimNeuronRequest): [Array<number>, bigint, bigint] => [
+  arrayBufferToArrayOfNumber(publicKey),
+  nonce,
+  dissolveDelayInSecs,
+];
+
+export const fromListProposalsRequest = ({
+  includeRewardStatus,
+  beforeProposal,
+  excludeTopic,
+  includeStatus,
+  limit,
+}: ListProposalsRequest): ListProposalInfo => {
+  return {
+    include_reward_status: includeRewardStatus,
+    before_proposal: beforeProposal ? [fromProposalId(beforeProposal)] : [],
+    limit: limit,
+    exclude_topic: excludeTopic,
+    include_status: includeStatus,
+  };
+};
+
+/* Protobuf is not supported yet
+export const fromAddHotKeyRequest = (request: AddHotKeyRequest): PbManageNeuron => {
+  const hotkeyPrincipal = new PbPrincipalId();
+  hotkeyPrincipal.setSerializedId(
+    Principal.fromText(request.principal).toUint8Array()
+  );
+
+  const hotkey = new PbManageNeuron.AddHotKey();
+  hotkey.setNewHotKey(hotkeyPrincipal);
+
+  const configure = new PbManageNeuron.Configure();
+  configure.setAddHotKey(hotkey);
+
+  const result = new PbManageNeuron();
+  result.setConfigure(configure);
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  result.setNeuronId(neuronId);
+
+  return result;
+};
+*/
+
+export const fromClaimOrRefreshNeuronRequest = (
+  request: ClaimOrRefreshNeuronRequest
+): RawManageNeuron => {
+  const rawCommand: RawCommand = {
+    ClaimOrRefresh: { by: [{ NeuronIdOrSubaccount: {} }] },
   };
 
-  private fromAmount(amount: E8s): Amount {
-    return {
-      e8s: amount,
-    };
+  return {
+    id: [],
+    command: [rawCommand],
+    neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
+  };
+};
+
+/* Protobuf is not supported yet
+export const fromMergeMaturityRequest = (
+  request: MergeMaturityRequest
+): PbManageNeuron => {
+  const mergeMaturity = new PbManageNeuron.MergeMaturity();
+  mergeMaturity.setPercentageToMerge(request.percentageToMerge);
+  const manageNeuron = new PbManageNeuron();
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  manageNeuron.setNeuronId(neuronId);
+  manageNeuron.setMergeMaturity(mergeMaturity);
+  return manageNeuron;
+};
+*/
+
+/* Protobuf is not supported yet
+export const fromRemoveHotKeyRequest = (
+  request: RemoveHotKeyRequest
+): PbManageNeuron => {
+  const hotkeyPrincipal = new PbPrincipalId();
+  hotkeyPrincipal.setSerializedId(
+    Principal.fromText(request.principal).toUint8Array()
+  );
+
+  const command = new PbManageNeuron.RemoveHotKey();
+  command.setHotKeyToRemove(hotkeyPrincipal);
+
+  const configure = new PbManageNeuron.Configure();
+  configure.setRemoveHotKey(command);
+
+  const result = new PbManageNeuron();
+  result.setConfigure(configure);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  result.setNeuronId(neuronId);
+
+  return result;
+};
+
+export const fromStartDissolvingRequest = (
+  request: StartDissolvingRequest
+): PbManageNeuron => {
+  const configure = new PbManageNeuron.Configure();
+  configure.setStartDissolving(new PbManageNeuron.StartDissolving());
+
+  const result = new PbManageNeuron();
+  result.setConfigure(configure);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  result.setNeuronId(neuronId);
+
+  return result;
+};
+
+export const fromStopDissolvingRequest = (
+  request: StopDissolvingRequest
+): PbManageNeuron => {
+  const configure = new PbManageNeuron.Configure();
+  configure.setStopDissolving(new PbManageNeuron.StopDissolving());
+
+  const result = new PbManageNeuron();
+  result.setConfigure(configure);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  result.setNeuronId(neuronId);
+
+  return result;
+};
+
+export const fromIncreaseDissolveDelayRequest = (
+  request: IncreaseDissolveDelayRequest
+): PbManageNeuron => {
+  const command = new PbManageNeuron.IncreaseDissolveDelay();
+  command.setAdditionalDissolveDelaySeconds(
+    request.additionalDissolveDelaySeconds
+  );
+
+  const configure = new PbManageNeuron.Configure();
+  configure.setIncreaseDissolveDelay(command);
+
+  const result = new PbManageNeuron();
+  result.setConfigure(configure);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  result.setNeuronId(neuronId);
+
+  return result;
+};
+
+export const fromFollowRequest = (request: FollowRequest): PbManageNeuron => {
+  const follow = new PbManageNeuron.Follow();
+  follow.setTopic(request.topic);
+  follow.setFolloweesList(
+    request.followees.map((followee) => {
+      const neuronId = new PbNeuronId();
+      neuronId.setId(followee.toString());
+      return neuronId;
+    })
+  );
+  const manageNeuron = new PbManageNeuron();
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  manageNeuron.setNeuronId(neuronId);
+  manageNeuron.setFollow(follow);
+  return manageNeuron;
+};
+
+export const fromRegisterVoteRequest = (
+  request: RegisterVoteRequest
+): PbManageNeuron => {
+  const registerVote = new PbManageNeuron.RegisterVote();
+  registerVote.setVote(request.vote);
+  const proposal = new PbProposalId();
+  proposal.setId(request.proposal.toString());
+  registerVote.setProposal(proposal);
+  const manageNeuron = new PbManageNeuron();
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  manageNeuron.setNeuronId(neuronId);
+  manageNeuron.setRegisterVote(registerVote);
+  return manageNeuron;
+};
+
+export const fromSpawnRequest = (request: SpawnRequest): PbManageNeuron => {
+  const spawn = new PbManageNeuron.Spawn();
+
+  if (request.newController) {
+    const newController = new PbPrincipalId();
+    newController.setSerializedId(
+      Principal.fromText(request.newController).toUint8Array().slice(4)
+    );
+    spawn.setNewController(newController);
   }
 
-  private fromAccountIdentifier(
-    accountIdentifier: AccountIdentifier
-  ): RawAccountIdentifier {
-    const bytes = accountIdentifierToBytes(accountIdentifier);
-    return {
-      hash: arrayBufferToArrayOfNumber(bytes),
-    };
+  const manageNeuron = new PbManageNeuron();
+  manageNeuron.setSpawn(spawn);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  manageNeuron.setNeuronId(neuronId);
+  return manageNeuron;
+};
+*/
+
+export const fromSplitRequest = (request: SplitRequest): RawManageNeuron => {
+  const rawCommand: RawCommand = {
+    Split: {
+      amount_e8s: request.amount,
+    },
+  };
+
+  return {
+    id: [],
+    command: [rawCommand],
+    neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
+  };
+};
+
+/* Protobuf is not supported yet
+export const fromDisburseRequest = (request: DisburseRequest): PbManageNeuron => {
+  const disburse = new PbManageNeuron.Disburse();
+
+  if (request.toAccountId) {
+    const toAccountIdentifier = new PbAccountIdentifier();
+    toAccountIdentifier.setHash(
+      Uint8Array.from(Buffer.from(request.toAccountId, "hex"))
+    );
+    disburse.setToAccount(toAccountIdentifier);
   }
 
-  private fromRewardMode(rewardMode: RewardMode): RawRewardMode {
-    if ("RewardToNeuron" in rewardMode) {
-      return {
-        RewardToNeuron: {
-          dissolve_delay_seconds:
-            rewardMode.RewardToNeuron.dissolveDelaySeconds,
-        },
-      };
-    } else if ("RewardToAccount" in rewardMode) {
-      return {
-        RewardToAccount: {
-          to_account:
-            rewardMode.RewardToAccount.toAccount != null
-              ? [
-                  this.fromAccountIdentifier(
-                    rewardMode.RewardToAccount.toAccount
-                  ),
-                ]
-              : [],
-        },
-      };
-    } else {
-      // If there's a missing rewardMode above, this line will cause a compiler error.
-      throw new UnsupportedValueError(rewardMode);
-    }
+  if (request.amount != null) {
+    const amount = new PbManageNeuron.Disburse.Amount();
+    amount.setE8s(request.amount.toString());
+    disburse.setAmount(amount);
   }
 
-  private fromClaimOrRefreshBy(by: By): RawBy {
-    if ("NeuronIdOrSubaccount" in by) {
-      return {
-        NeuronIdOrSubaccount: {},
-      };
-    } else if ("Memo" in by) {
-      return {
-        Memo: by.Memo,
-      };
-    } else if ("MemoAndController" in by) {
-      return {
-        MemoAndController: {
-          memo: by.MemoAndController.memo,
-          controller: by.MemoAndController.controller
-            ? [by.MemoAndController.controller]
-            : [],
-        },
-      };
-    } else {
-      // Ensures all cases are covered at compile-time.
-      throw new UnsupportedValueError(by);
-    }
-  }
-}
+  const manageNeuron = new PbManageNeuron();
+  manageNeuron.setDisburse(disburse);
+
+  const neuronId = new PbNeuronId();
+  neuronId.setId(request.neuronId.toString());
+  manageNeuron.setNeuronId(neuronId);
+  return manageNeuron;
+};
+*/
+
+export const fromDisburseToNeuronRequest = (
+  request: DisburseToNeuronRequest
+): RawManageNeuron => {
+  const rawCommand: RawCommand = {
+    DisburseToNeuron: {
+      dissolve_delay_seconds: request.dissolveDelaySeconds,
+      kyc_verified: request.kycVerified,
+      amount_e8s: request.amount,
+      new_controller:
+        request.newController != null
+          ? [Principal.fromText(request.newController)]
+          : [],
+      nonce: request.nonce,
+    },
+  };
+
+  return {
+    id: [],
+    command: [rawCommand],
+    neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
+  };
+};
+
+export const fromMakeProposalRequest = (
+  request: MakeProposalRequest
+): RawManageNeuron => {
+  const rawCommand: RawCommand = {
+    MakeProposal: {
+      url: request.url,
+      title: request.title != null ? [request.title] : [],
+      summary: request.summary,
+      action: [fromAction(request.action)],
+    },
+  };
+
+  return {
+    id: [],
+    command: [rawCommand],
+    neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
+  };
+};

--- a/src/canisters/governance/response.converters.ts
+++ b/src/canisters/governance/response.converters.ts
@@ -1,7 +1,3 @@
-// Conversion methods.
-// Note: Protobuf methods have not been imported yet.
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { Principal } from "@dfinity/principal";
 import {
   AccountIdentifier as RawAccountIdentifier,
@@ -66,706 +62,674 @@ import {
 // import { ManageNeuronResponse as PbManageNeuronResponse } from "../../proto/governance_pb";
 import { convertNnsFunctionPayload, getNnsFunctionName } from "./payloads";
 
-export class ResponseConverters {
-  public toProposalInfo = (proposalInfo: RawProposalInfo): ProposalInfo => {
+const toNeuronInfo = (
+  neuronId: bigint,
+  principalString: string,
+  neuronInfo: RawNeuronInfo,
+  rawNeuron?: RawNeuron
+): NeuronInfo => {
+  const fullNeuron = rawNeuron
+    ? toNeuron(rawNeuron, principalString)
+    : undefined;
+  return {
+    neuronId: neuronId,
+    dissolveDelaySeconds: neuronInfo.dissolve_delay_seconds,
+    recentBallots: neuronInfo.recent_ballots.map(toBallotInfo),
+    createdTimestampSeconds: neuronInfo.created_timestamp_seconds,
+    state: neuronInfo.state,
+    joinedCommunityFundTimestampSeconds: neuronInfo
+      .joined_community_fund_timestamp_seconds.length
+      ? neuronInfo.joined_community_fund_timestamp_seconds[0]
+      : undefined,
+    retrievedAtTimestampSeconds: neuronInfo.retrieved_at_timestamp_seconds,
+    votingPower: neuronInfo.voting_power,
+    ageSeconds: neuronInfo.age_seconds,
+    fullNeuron: fullNeuron,
+  };
+};
+
+const toNeuron = (neuron: RawNeuron, principalString: string): Neuron => ({
+  id: neuron.id.length ? toNeuronId(neuron.id[0]) : undefined,
+  isCurrentUserController: neuron.controller.length
+    ? neuron.controller[0].toString() === principalString
+    : undefined,
+  controller: neuron.controller.length
+    ? neuron.controller[0].toString()
+    : undefined,
+  recentBallots: neuron.recent_ballots.map(toBallotInfo),
+  kycVerified: neuron.kyc_verified,
+  notForProfit: neuron.not_for_profit,
+  cachedNeuronStake: neuron.cached_neuron_stake_e8s,
+  createdTimestampSeconds: neuron.created_timestamp_seconds,
+  maturityE8sEquivalent: neuron.maturity_e8s_equivalent,
+  agingSinceTimestampSeconds: neuron.aging_since_timestamp_seconds,
+  neuronFees: neuron.neuron_fees_e8s,
+  hotKeys: neuron.hot_keys.map((p) => p.toString()),
+  accountIdentifier: principalToAccountIdentifier(
+    GOVERNANCE_CANISTER_ID,
+    arrayOfNumberToUint8Array(neuron.account)
+  ),
+  joinedCommunityFundTimestampSeconds: neuron
+    .joined_community_fund_timestamp_seconds.length
+    ? neuron.joined_community_fund_timestamp_seconds[0]
+    : undefined,
+  dissolveState: neuron.dissolve_state.length
+    ? toDissolveState(neuron.dissolve_state[0])
+    : undefined,
+  followees: neuron.followees.map(([n, f]) => toFollowees(n, f)),
+});
+
+const toBallotInfo = ({ vote, proposal_id }: RawBallotInfo): BallotInfo => ({
+  vote,
+  proposalId: proposal_id.length ? toNeuronId(proposal_id[0]) : undefined,
+});
+
+const toDissolveState = (dissolveState: RawDissolveState): DissolveState => {
+  if ("DissolveDelaySeconds" in dissolveState) {
     return {
-      id: proposalInfo.id.length
-        ? this.toNeuronId(proposalInfo.id[0])
-        : undefined,
-      ballots: proposalInfo.ballots.map((b) => this.toBallot(b[0], b[1])),
-      rejectCost: proposalInfo.reject_cost_e8s,
-      proposalTimestampSeconds: proposalInfo.proposal_timestamp_seconds,
-      rewardEventRound: proposalInfo.reward_event_round,
-      failedTimestampSeconds: proposalInfo.failed_timestamp_seconds,
-      decidedTimestampSeconds: proposalInfo.decided_timestamp_seconds,
-      proposal: proposalInfo.proposal.length
-        ? this.toProposal(proposalInfo.proposal[0])
-        : undefined,
-      proposer: proposalInfo.proposer.length
-        ? this.toNeuronId(proposalInfo.proposer[0])
-        : undefined,
-      latestTally: proposalInfo.latest_tally.length
-        ? this.toTally(proposalInfo.latest_tally[0])
-        : undefined,
-      executedTimestampSeconds: proposalInfo.executed_timestamp_seconds,
-      topic: proposalInfo.topic,
-      status: proposalInfo.status,
-      rewardStatus: proposalInfo.reward_status,
+      DissolveDelaySeconds: dissolveState.DissolveDelaySeconds,
     };
-  };
+  } else {
+    return {
+      WhenDissolvedTimestampSeconds:
+        dissolveState.WhenDissolvedTimestampSeconds,
+    };
+  }
+};
 
-  public toArrayOfNeuronInfo = (
-    response: RawListNeuronsResponse,
-    principal: Principal
-  ): Array<NeuronInfo> => {
-    const principalString = principal.toString();
+const toFollowees = (topic: number, followees: RawFollowees): Followees => ({
+  topic: topic,
+  followees: followees.followees.map(toNeuronId),
+});
 
-    return response.neuron_infos.map(([id, neuronInfo]) =>
-      this.toNeuronInfo(
-        id,
-        principalString,
-        neuronInfo,
-        response.full_neurons.find(
-          (neuron) => neuron.id.length && neuron.id[0].id === id
-        )
-      )
-    );
-  };
+const toNeuronId = ({ id }: RawNeuronId): NeuronId => id;
 
-  private toNeuronInfo(
-    neuronId: bigint,
-    principalString: string,
-    neuronInfo: RawNeuronInfo,
-    rawNeuron?: RawNeuron
-  ): NeuronInfo {
-    const fullNeuron = rawNeuron
-      ? this.toNeuron(rawNeuron, principalString)
+const toNeuronIdOrSubaccount = (
+  neuronIdOrSubaccount: RawNeuronIdOrSubaccount
+): NeuronIdOrSubaccount => {
+  if ("NeuronId" in neuronIdOrSubaccount) {
+    return { NeuronId: neuronIdOrSubaccount.NeuronId.id };
+  }
+  if ("Subaccount" in neuronIdOrSubaccount) {
+    return { Subaccount: neuronIdOrSubaccount.Subaccount };
+  }
+  throw new UnsupportedValueError(neuronIdOrSubaccount);
+};
+
+const toBallot = (neuronId: bigint, ballot: RawBallot): Ballot => ({
+  neuronId: neuronId,
+  vote: ballot.vote,
+  votingPower: ballot.voting_power,
+});
+
+const toProposal = ({
+  title,
+  url,
+  action,
+  summary,
+}: RawProposal): Proposal => ({
+  title: title.length ? title[0] : undefined,
+  url,
+  action: action.length ? toAction(action[0]) : undefined,
+  summary,
+});
+
+const toAction = (action: RawAction): Action => {
+  if ("ExecuteNnsFunction" in action) {
+    const executeNnsFunction = action.ExecuteNnsFunction;
+    const payloadBytes = arrayOfNumberToArrayBuffer(executeNnsFunction.payload);
+    const payload = payloadBytes.byteLength
+      ? convertNnsFunctionPayload(executeNnsFunction.nns_function, payloadBytes)
       : undefined;
+
     return {
-      neuronId: neuronId,
-      dissolveDelaySeconds: neuronInfo.dissolve_delay_seconds,
-      recentBallots: neuronInfo.recent_ballots.map(this.toBallotInfo),
-      createdTimestampSeconds: neuronInfo.created_timestamp_seconds,
-      state: neuronInfo.state,
-      joinedCommunityFundTimestampSeconds: neuronInfo
-        .joined_community_fund_timestamp_seconds.length
-        ? neuronInfo.joined_community_fund_timestamp_seconds[0]
-        : undefined,
-      retrievedAtTimestampSeconds: neuronInfo.retrieved_at_timestamp_seconds,
-      votingPower: neuronInfo.voting_power,
-      ageSeconds: neuronInfo.age_seconds,
-      fullNeuron: fullNeuron,
+      ExecuteNnsFunction: {
+        nnsFunctionId: executeNnsFunction.nns_function,
+        nnsFunctionName: getNnsFunctionName(executeNnsFunction.nns_function),
+        payload,
+        payloadBytes,
+      },
+    };
+  }
+  if ("ManageNeuron" in action) {
+    const manageNeuron = action.ManageNeuron;
+    return {
+      ManageNeuron: {
+        id: manageNeuron.id.length ? toNeuronId(manageNeuron.id[0]) : undefined,
+        command: manageNeuron.command.length
+          ? toCommand(manageNeuron.command[0])
+          : undefined,
+        neuronIdOrSubaccount: manageNeuron.neuron_id_or_subaccount.length
+          ? toNeuronIdOrSubaccount(manageNeuron.neuron_id_or_subaccount[0])
+          : undefined,
+      },
+    };
+  }
+  if ("ApproveGenesisKyc" in action) {
+    const approveKyc = action.ApproveGenesisKyc;
+    return {
+      ApproveGenesisKyc: {
+        principals: approveKyc.principals.map((p) => p.toString()),
+      },
+    };
+  }
+  if ("ManageNetworkEconomics" in action) {
+    const networkEconomics = action.ManageNetworkEconomics;
+    return {
+      ManageNetworkEconomics: {
+        neuronMinimumStake: networkEconomics.neuron_minimum_stake_e8s,
+        maxProposalsToKeepPerTopic:
+          networkEconomics.max_proposals_to_keep_per_topic,
+        neuronManagementFeePerProposal:
+          networkEconomics.neuron_management_fee_per_proposal_e8s,
+        rejectCost: networkEconomics.reject_cost_e8s,
+        transactionFee: networkEconomics.transaction_fee_e8s,
+        neuronSpawnDissolveDelaySeconds:
+          networkEconomics.neuron_spawn_dissolve_delay_seconds,
+        minimumIcpXdrRate: networkEconomics.minimum_icp_xdr_rate,
+        maximumNodeProviderRewards:
+          networkEconomics.maximum_node_provider_rewards_e8s,
+      },
+    };
+  }
+  if ("RewardNodeProvider" in action) {
+    const rewardNodeProvider = action.RewardNodeProvider;
+    return {
+      RewardNodeProvider: {
+        nodeProvider: rewardNodeProvider.node_provider.length
+          ? toNodeProvider(rewardNodeProvider.node_provider[0])
+          : undefined,
+        amountE8s: rewardNodeProvider.amount_e8s,
+        rewardMode: rewardNodeProvider.reward_mode.length
+          ? toRewardMode(rewardNodeProvider.reward_mode[0])
+          : undefined,
+      },
+    };
+  }
+  if ("RewardNodeProviders" in action) {
+    const rewardNodeProviders = action.RewardNodeProviders;
+    return {
+      RewardNodeProviders: {
+        rewards: rewardNodeProviders.rewards.map((r) => ({
+          nodeProvider: r.node_provider.length
+            ? toNodeProvider(r.node_provider[0])
+            : undefined,
+          amountE8s: r.amount_e8s,
+          rewardMode: r.reward_mode.length
+            ? toRewardMode(r.reward_mode[0])
+            : undefined,
+        })),
+      },
+    };
+  }
+  if ("AddOrRemoveNodeProvider" in action) {
+    const addOrRemoveNodeProvider = action.AddOrRemoveNodeProvider;
+    return {
+      AddOrRemoveNodeProvider: {
+        change: addOrRemoveNodeProvider.change.length
+          ? toChange(addOrRemoveNodeProvider.change[0])
+          : undefined,
+      },
+    };
+  }
+  if ("Motion" in action) {
+    const motion = action.Motion;
+    return {
+      Motion: {
+        motionText: motion.motion_text,
+      },
+    };
+  }
+  if ("SetDefaultFollowees" in action) {
+    const setDefaultFollowees = action.SetDefaultFollowees;
+    return {
+      SetDefaultFollowees: {
+        defaultFollowees: setDefaultFollowees.default_followees.map(([n, f]) =>
+          toFollowees(n, f)
+        ),
+      },
+    };
+  }
+  if ("RegisterKnownNeuron" in action) {
+    const knownNeuron = action.RegisterKnownNeuron;
+    return {
+      RegisterKnownNeuron: toKnownNeuron(knownNeuron),
     };
   }
 
-  public toListProposalsResponse = (
-    response: RawListProposalInfoResponse
-  ): ListProposalsResponse => {
+  throw new UnsupportedValueError(action);
+};
+
+const toTally = (tally: RawTally): Tally => {
+  return {
+    no: tally.no,
+    yes: tally.yes,
+    total: tally.total,
+    timestampSeconds: tally.timestamp_seconds,
+  };
+};
+
+const toCommand = (command: RawCommand): Command => {
+  if ("Spawn" in command) {
+    const spawn = command.Spawn;
     return {
-      proposals: response.proposal_info.map(this.toProposalInfo),
+      Spawn: {
+        newController: spawn.new_controller.length
+          ? spawn.new_controller[0].toString()
+          : undefined,
+      },
     };
-  };
-
-  public toKnownNeuron = (response: RawKnownNeuron): KnownNeuron => {
+  }
+  if ("Split" in command) {
+    const split = command.Split;
     return {
-      id: response.id[0]?.id ?? BigInt(0),
-      name: response.known_neuron_data[0]?.name ?? "",
-      description: response.known_neuron_data[0]?.description[0] ?? "",
+      Split: {
+        amount: split.amount_e8s,
+      },
     };
-  };
-
-  /* Protobuf is not supported yet.
-  public toSpawnResponse = (
-    response: PbManageNeuronResponse
-  ): SpawnResponse => {
-    const createdNeuronId = response.getSpawn()?.getCreatedNeuronId();
-
-    if (!createdNeuronId) {
-      throw this.throwUnrecognisedTypeError("response", response);
-    }
-
+  }
+  if ("Follow" in command) {
+    const follow = command.Follow;
     return {
-      createdNeuronId: BigInt(createdNeuronId.getId()),
+      Follow: {
+        topic: follow.topic,
+        followees: follow.followees.map(toNeuronId),
+      },
     };
-  };
-  */
-
-  public toSplitResponse = (response: RawManageNeuronResponse): NeuronId => {
-    const command = response.command.length ? response.command[0] : undefined;
-
-    if (command && "Split" in command) {
-      const createdNeuronId = command.Split.created_neuron_id;
-      if (createdNeuronId.length) {
-        return createdNeuronId[0].id;
-      }
-    }
-    throw this.throwUnrecognisedTypeError("response", response);
-  };
-
-  /* Protobuf is not supported yet.
-  public toDisburseResponse = (
-    response: PbManageNeuronResponse
-  ): DisburseResponse => {
-    const blockHeight = response.getDisburse()?.getTransferBlockHeight();
-
-    if (!blockHeight) {
-      throw this.throwUnrecognisedTypeError("response", response);
-    }
-
+  }
+  if ("ClaimOrRefresh" in command) {
+    const claimOrRefresh = command.ClaimOrRefresh;
     return {
-      transferBlockHeight: BigInt(blockHeight),
+      ClaimOrRefresh: {
+        by: claimOrRefresh.by.length
+          ? toClaimOrRefreshBy(claimOrRefresh.by[0])
+          : undefined,
+      },
     };
-  };
-  */
-
-  public toDisburseToNeuronResult = (
-    response: RawManageNeuronResponse
-  ): DisburseToNeuronResponse => {
-    const command = response.command;
-    if (
-      command.length &&
-      "Spawn" in command[0] &&
-      command[0].Spawn.created_neuron_id.length
-    ) {
-      return {
-        createdNeuronId: command[0].Spawn.created_neuron_id[0].id,
-      };
-    }
-    throw this.throwUnrecognisedTypeError("response", response);
-  };
-
-  public toClaimOrRefreshNeuronResponse = (
-    response: RawManageNeuronResponse
-  ): Option<NeuronId> => {
-    const command = response.command;
-    if (command.length && "ClaimOrRefresh" in command[0]) {
-      return command[0].ClaimOrRefresh.refreshed_neuron_id.length
-        ? command[0].ClaimOrRefresh.refreshed_neuron_id[0].id
-        : undefined;
-    }
-    throw this.throwUnrecognisedTypeError("response", response);
-  };
-
-  /* Protobuf is not supported yet.
-  public toMergeMaturityResponse = (
-    response: PbManageNeuronResponse
-  ): MergeMaturityResponse => {
-    const error = response.getError();
-    if (error) {
-      throw error.getErrorMessage();
-    }
-
-    const mergeMaturityResponse = response.getMergeMaturity();
-    if (mergeMaturityResponse) {
-      return {
-        mergedMaturityE8s: BigInt(mergeMaturityResponse.getMergedMaturityE8s()),
-        newStakeE8s: BigInt(mergeMaturityResponse.getNewStakeE8s()),
-      };
-    }
-
-    throw this.throwUnrecognisedTypeError("response", response);
-  };
-  */
-
-  public toMakeProposalResponse = (
-    response: RawManageNeuronResponse
-  ): MakeProposalResponse => {
-    const command = response.command;
-    if (
-      command.length &&
-      "MakeProposal" in command[0] &&
-      command[0].MakeProposal.proposal_id.length
-    ) {
-      return {
-        proposalId: command[0].MakeProposal.proposal_id[0].id,
-      };
-    }
-    throw this.throwUnrecognisedTypeError("response", response);
-  };
-
-  private toNeuron = (neuron: RawNeuron, principalString: string): Neuron => {
+  }
+  if ("Configure" in command) {
+    const configure = command.Configure;
     return {
-      id: neuron.id.length ? this.toNeuronId(neuron.id[0]) : undefined,
-      isCurrentUserController: neuron.controller.length
-        ? neuron.controller[0].toString() === principalString
-        : undefined,
-      controller: neuron.controller.length
-        ? neuron.controller[0].toString()
-        : undefined,
-      recentBallots: neuron.recent_ballots.map(this.toBallotInfo),
-      kycVerified: neuron.kyc_verified,
-      notForProfit: neuron.not_for_profit,
-      cachedNeuronStake: neuron.cached_neuron_stake_e8s,
-      createdTimestampSeconds: neuron.created_timestamp_seconds,
-      maturityE8sEquivalent: neuron.maturity_e8s_equivalent,
-      agingSinceTimestampSeconds: neuron.aging_since_timestamp_seconds,
-      neuronFees: neuron.neuron_fees_e8s,
-      hotKeys: neuron.hot_keys.map((p) => p.toString()),
-      accountIdentifier: principalToAccountIdentifier(
-        GOVERNANCE_CANISTER_ID,
-        arrayOfNumberToUint8Array(neuron.account)
-      ),
-      joinedCommunityFundTimestampSeconds: neuron
-        .joined_community_fund_timestamp_seconds.length
-        ? neuron.joined_community_fund_timestamp_seconds[0]
-        : undefined,
-      dissolveState: neuron.dissolve_state.length
-        ? this.toDissolveState(neuron.dissolve_state[0])
-        : undefined,
-      followees: neuron.followees.map(([n, f]) => this.toFollowees(n, f)),
+      Configure: {
+        operation: configure.operation.length
+          ? toOperation(configure.operation[0])
+          : undefined,
+      },
     };
-  };
-
-  private toBallotInfo = (ballotInfo: RawBallotInfo): BallotInfo => {
+  }
+  if ("RegisterVote" in command) {
+    const registerVote = command.RegisterVote;
     return {
-      vote: ballotInfo.vote,
-      proposalId: ballotInfo.proposal_id.length
-        ? this.toNeuronId(ballotInfo.proposal_id[0])
-        : undefined,
+      RegisterVote: {
+        vote: registerVote.vote,
+        proposal: registerVote.proposal.length
+          ? toNeuronId(registerVote.proposal[0])
+          : undefined,
+      },
     };
-  };
-
-  private toDissolveState = (
-    dissolveState: RawDissolveState
-  ): DissolveState => {
-    if ("DissolveDelaySeconds" in dissolveState) {
-      return {
-        DissolveDelaySeconds: dissolveState.DissolveDelaySeconds,
-      };
-    } else {
-      return {
-        WhenDissolvedTimestampSeconds:
-          dissolveState.WhenDissolvedTimestampSeconds,
-      };
-    }
-  };
-
-  private toFollowees = (topic: number, followees: RawFollowees): Followees => {
+  }
+  if ("DisburseToNeuron" in command) {
+    const disburseToNeuron = command.DisburseToNeuron;
     return {
-      topic: topic,
-      followees: followees.followees.map(this.toNeuronId),
+      DisburseToNeuron: {
+        dissolveDelaySeconds: disburseToNeuron.dissolve_delay_seconds,
+        kycVerified: disburseToNeuron.kyc_verified,
+        amount: disburseToNeuron.amount_e8s,
+        newController: disburseToNeuron.new_controller.length
+          ? disburseToNeuron.new_controller[0].toString()
+          : undefined,
+        nonce: disburseToNeuron.nonce,
+      },
     };
-  };
-
-  private toNeuronId = (neuronId: RawNeuronId): NeuronId => {
-    return neuronId.id;
-  };
-
-  private toNeuronIdOrSubaccount = (
-    neuronIdOrSubaccount: RawNeuronIdOrSubaccount
-  ): NeuronIdOrSubaccount => {
-    if ("NeuronId" in neuronIdOrSubaccount) {
-      return { NeuronId: neuronIdOrSubaccount.NeuronId.id };
-    }
-    if ("Subaccount" in neuronIdOrSubaccount) {
-      return { Subaccount: neuronIdOrSubaccount.Subaccount };
-    }
-    throw new UnsupportedValueError(neuronIdOrSubaccount);
-  };
-
-  private toBallot = (neuronId: bigint, ballot: RawBallot): Ballot => {
+  }
+  if ("MergeMaturity" in command) {
+    const mergeMaturity = command.MergeMaturity;
     return {
-      neuronId: neuronId,
-      vote: ballot.vote,
-      votingPower: ballot.voting_power,
+      MergeMaturity: {
+        percentageToMerge: mergeMaturity.percentage_to_merge,
+      },
     };
-  };
-
-  private toProposal = (proposal: RawProposal): Proposal => {
+  }
+  if ("MakeProposal" in command) {
+    const makeProposal = command.MakeProposal;
     return {
-      title: proposal.title.length ? proposal.title[0] : undefined,
-      url: proposal.url,
-      action: proposal.action.length
-        ? this.toAction(proposal.action[0])
-        : undefined,
-      summary: proposal.summary,
+      MakeProposal: {
+        title: makeProposal.title.length ? makeProposal.title[0] : undefined,
+        url: makeProposal.url,
+        action: makeProposal.action.length
+          ? toAction(makeProposal.action[0])
+          : undefined,
+        summary: makeProposal.summary,
+      },
     };
-  };
-
-  private toAction = (action: RawAction): Action => {
-    if ("ExecuteNnsFunction" in action) {
-      const executeNnsFunction = action.ExecuteNnsFunction;
-      const payloadBytes = arrayOfNumberToArrayBuffer(
-        executeNnsFunction.payload
-      );
-      const payload = payloadBytes.byteLength
-        ? convertNnsFunctionPayload(
-            executeNnsFunction.nns_function,
-            payloadBytes
-          )
-        : undefined;
-
-      return {
-        ExecuteNnsFunction: {
-          nnsFunctionId: executeNnsFunction.nns_function,
-          nnsFunctionName: getNnsFunctionName(executeNnsFunction.nns_function),
-          payload,
-          payloadBytes,
-        },
-      };
-    }
-    if ("ManageNeuron" in action) {
-      const manageNeuron = action.ManageNeuron;
-      return {
-        ManageNeuron: {
-          id: manageNeuron.id.length
-            ? this.toNeuronId(manageNeuron.id[0])
-            : undefined,
-          command: manageNeuron.command.length
-            ? this.toCommand(manageNeuron.command[0])
-            : undefined,
-          neuronIdOrSubaccount: manageNeuron.neuron_id_or_subaccount.length
-            ? this.toNeuronIdOrSubaccount(
-                manageNeuron.neuron_id_or_subaccount[0]
-              )
-            : undefined,
-        },
-      };
-    }
-    if ("ApproveGenesisKyc" in action) {
-      const approveKyc = action.ApproveGenesisKyc;
-      return {
-        ApproveGenesisKyc: {
-          principals: approveKyc.principals.map((p) => p.toString()),
-        },
-      };
-    }
-    if ("ManageNetworkEconomics" in action) {
-      const networkEconomics = action.ManageNetworkEconomics;
-      return {
-        ManageNetworkEconomics: {
-          neuronMinimumStake: networkEconomics.neuron_minimum_stake_e8s,
-          maxProposalsToKeepPerTopic:
-            networkEconomics.max_proposals_to_keep_per_topic,
-          neuronManagementFeePerProposal:
-            networkEconomics.neuron_management_fee_per_proposal_e8s,
-          rejectCost: networkEconomics.reject_cost_e8s,
-          transactionFee: networkEconomics.transaction_fee_e8s,
-          neuronSpawnDissolveDelaySeconds:
-            networkEconomics.neuron_spawn_dissolve_delay_seconds,
-          minimumIcpXdrRate: networkEconomics.minimum_icp_xdr_rate,
-          maximumNodeProviderRewards:
-            networkEconomics.maximum_node_provider_rewards_e8s,
-        },
-      };
-    }
-    if ("RewardNodeProvider" in action) {
-      const rewardNodeProvider = action.RewardNodeProvider;
-      return {
-        RewardNodeProvider: {
-          nodeProvider: rewardNodeProvider.node_provider.length
-            ? this.toNodeProvider(rewardNodeProvider.node_provider[0])
-            : undefined,
-          amountE8s: rewardNodeProvider.amount_e8s,
-          rewardMode: rewardNodeProvider.reward_mode.length
-            ? this.toRewardMode(rewardNodeProvider.reward_mode[0])
-            : undefined,
-        },
-      };
-    }
-    if ("RewardNodeProviders" in action) {
-      const rewardNodeProviders = action.RewardNodeProviders;
-      return {
-        RewardNodeProviders: {
-          rewards: rewardNodeProviders.rewards.map((r) => ({
-            nodeProvider: r.node_provider.length
-              ? this.toNodeProvider(r.node_provider[0])
-              : undefined,
-            amountE8s: r.amount_e8s,
-            rewardMode: r.reward_mode.length
-              ? this.toRewardMode(r.reward_mode[0])
-              : undefined,
-          })),
-        },
-      };
-    }
-    if ("AddOrRemoveNodeProvider" in action) {
-      const addOrRemoveNodeProvider = action.AddOrRemoveNodeProvider;
-      return {
-        AddOrRemoveNodeProvider: {
-          change: addOrRemoveNodeProvider.change.length
-            ? this.toChange(addOrRemoveNodeProvider.change[0])
-            : undefined,
-        },
-      };
-    }
-    if ("Motion" in action) {
-      const motion = action.Motion;
-      return {
-        Motion: {
-          motionText: motion.motion_text,
-        },
-      };
-    }
-    if ("SetDefaultFollowees" in action) {
-      const setDefaultFollowees = action.SetDefaultFollowees;
-      return {
-        SetDefaultFollowees: {
-          defaultFollowees: setDefaultFollowees.default_followees.map(
-            ([n, f]) => this.toFollowees(n, f)
-          ),
-        },
-      };
-    }
-    if ("RegisterKnownNeuron" in action) {
-      const knownNeuron = action.RegisterKnownNeuron;
-      return {
-        RegisterKnownNeuron: this.toKnownNeuron(knownNeuron),
-      };
-    }
-
-    throw new UnsupportedValueError(action);
-  };
-
-  private toTally = (tally: RawTally): Tally => {
+  }
+  if ("Disburse" in command) {
+    const disburse = command.Disburse;
     return {
-      no: tally.no,
-      yes: tally.yes,
-      total: tally.total,
-      timestampSeconds: tally.timestamp_seconds,
+      Disburse: {
+        toAccountId: disburse.to_account.length
+          ? toAccountIdentifier(disburse.to_account[0])
+          : undefined,
+        amount: disburse.amount.length
+          ? toAmount(disburse.amount[0])
+          : undefined,
+      },
     };
-  };
-
-  private toCommand = (command: RawCommand): Command => {
-    if ("Spawn" in command) {
-      const spawn = command.Spawn;
-      return {
-        Spawn: {
-          newController: spawn.new_controller.length
-            ? spawn.new_controller[0].toString()
-            : undefined,
-        },
-      };
-    }
-    if ("Split" in command) {
-      const split = command.Split;
-      return {
-        Split: {
-          amount: split.amount_e8s,
-        },
-      };
-    }
-    if ("Follow" in command) {
-      const follow = command.Follow;
-      return {
-        Follow: {
-          topic: follow.topic,
-          followees: follow.followees.map(this.toNeuronId),
-        },
-      };
-    }
-    if ("ClaimOrRefresh" in command) {
-      const claimOrRefresh = command.ClaimOrRefresh;
-      return {
-        ClaimOrRefresh: {
-          by: claimOrRefresh.by.length
-            ? this.toClaimOrRefreshBy(claimOrRefresh.by[0])
-            : undefined,
-        },
-      };
-    }
-    if ("Configure" in command) {
-      const configure = command.Configure;
-      return {
-        Configure: {
-          operation: configure.operation.length
-            ? this.toOperation(configure.operation[0])
-            : undefined,
-        },
-      };
-    }
-    if ("RegisterVote" in command) {
-      const registerVote = command.RegisterVote;
-      return {
-        RegisterVote: {
-          vote: registerVote.vote,
-          proposal: registerVote.proposal.length
-            ? this.toNeuronId(registerVote.proposal[0])
-            : undefined,
-        },
-      };
-    }
-    if ("DisburseToNeuron" in command) {
-      const disburseToNeuron = command.DisburseToNeuron;
-      return {
-        DisburseToNeuron: {
-          dissolveDelaySeconds: disburseToNeuron.dissolve_delay_seconds,
-          kycVerified: disburseToNeuron.kyc_verified,
-          amount: disburseToNeuron.amount_e8s,
-          newController: disburseToNeuron.new_controller.length
-            ? disburseToNeuron.new_controller[0].toString()
-            : undefined,
-          nonce: disburseToNeuron.nonce,
-        },
-      };
-    }
-    if ("MergeMaturity" in command) {
-      const mergeMaturity = command.MergeMaturity;
-      return {
-        MergeMaturity: {
-          percentageToMerge: mergeMaturity.percentage_to_merge,
-        },
-      };
-    }
-    if ("MakeProposal" in command) {
-      const makeProposal = command.MakeProposal;
-      return {
-        MakeProposal: {
-          title: makeProposal.title.length ? makeProposal.title[0] : undefined,
-          url: makeProposal.url,
-          action: makeProposal.action.length
-            ? this.toAction(makeProposal.action[0])
-            : undefined,
-          summary: makeProposal.summary,
-        },
-      };
-    }
-    if ("Disburse" in command) {
-      const disburse = command.Disburse;
-      return {
-        Disburse: {
-          toAccountId: disburse.to_account.length
-            ? this.toAccountIdentifier(disburse.to_account[0])
-            : undefined,
-          amount: disburse.amount.length
-            ? this.toAmount(disburse.amount[0])
-            : undefined,
-        },
-      };
-    }
-    if ("Merge" in command) {
-      const merge = command.Merge;
-      return {
-        Merge: {
-          sourceNeuronId: merge.source_neuron_id.length
-            ? merge.source_neuron_id[0].id
-            : undefined,
-        },
-      };
-    }
-    throw new UnsupportedValueError(command);
-  };
-
-  private toOperation = (operation: RawOperation): Operation => {
-    if ("RemoveHotKey" in operation) {
-      const removeHotKey = operation.RemoveHotKey;
-      return {
-        RemoveHotKey: {
-          hotKeyToRemove: removeHotKey.hot_key_to_remove.length
-            ? removeHotKey.hot_key_to_remove[0].toString()
-            : undefined,
-        },
-      };
-    }
-    if ("AddHotKey" in operation) {
-      const addHotKey = operation.AddHotKey;
-      return {
-        AddHotKey: {
-          newHotKey: addHotKey.new_hot_key.length
-            ? addHotKey.new_hot_key[0].toString()
-            : undefined,
-        },
-      };
-    }
-    if ("StopDissolving" in operation) {
-      return {
-        StopDissolving: {},
-      };
-    }
-    if ("StartDissolving" in operation) {
-      return {
-        StartDissolving: {},
-      };
-    }
-    if ("IncreaseDissolveDelay" in operation) {
-      const increaseDissolveDelay = operation.IncreaseDissolveDelay;
-      return {
-        IncreaseDissolveDelay: {
-          additionalDissolveDelaySeconds:
-            increaseDissolveDelay.additional_dissolve_delay_seconds,
-        },
-      };
-    }
-    if ("JoinCommunityFund" in operation) {
-      return operation;
-    }
-    if ("SetDissolveTimestamp" in operation) {
-      const setDissolveTimestamp = operation.SetDissolveTimestamp;
-      return {
-        SetDissolveTimestamp: {
-          dissolveTimestampSeconds:
-            setDissolveTimestamp.dissolve_timestamp_seconds,
-        },
-      };
-    }
-    throw new UnsupportedValueError(operation);
-  };
-
-  private toChange = (change: RawChange): Change => {
-    if ("ToRemove" in change) {
-      return {
-        ToRemove: this.toNodeProvider(change.ToRemove),
-      };
-    }
-    if ("ToAdd" in change) {
-      return {
-        ToAdd: this.toNodeProvider(change.ToAdd),
-      };
-    }
-    throw new UnsupportedValueError(change);
-  };
-
-  private toNodeProvider = (nodeProvider: RawNodeProvider): NodeProvider => {
+  }
+  if ("Merge" in command) {
+    const merge = command.Merge;
     return {
-      id: nodeProvider.id.length ? nodeProvider.id[0].toString() : undefined,
-      rewardAccount: nodeProvider.reward_account.length
-        ? this.toAccountIdentifier(nodeProvider.reward_account[0])
-        : undefined,
+      Merge: {
+        sourceNeuronId: merge.source_neuron_id.length
+          ? merge.source_neuron_id[0].id
+          : undefined,
+      },
     };
-  };
+  }
+  throw new UnsupportedValueError(command);
+};
 
-  private toAmount = (amount: RawAmount): E8s => {
-    return amount.e8s;
-  };
+const toOperation = (operation: RawOperation): Operation => {
+  if ("RemoveHotKey" in operation) {
+    const removeHotKey = operation.RemoveHotKey;
+    return {
+      RemoveHotKey: {
+        hotKeyToRemove: removeHotKey.hot_key_to_remove.length
+          ? removeHotKey.hot_key_to_remove[0].toString()
+          : undefined,
+      },
+    };
+  }
+  if ("AddHotKey" in operation) {
+    const addHotKey = operation.AddHotKey;
+    return {
+      AddHotKey: {
+        newHotKey: addHotKey.new_hot_key.length
+          ? addHotKey.new_hot_key[0].toString()
+          : undefined,
+      },
+    };
+  }
+  if ("StopDissolving" in operation) {
+    return {
+      StopDissolving: {},
+    };
+  }
+  if ("StartDissolving" in operation) {
+    return {
+      StartDissolving: {},
+    };
+  }
+  if ("IncreaseDissolveDelay" in operation) {
+    const increaseDissolveDelay = operation.IncreaseDissolveDelay;
+    return {
+      IncreaseDissolveDelay: {
+        additionalDissolveDelaySeconds:
+          increaseDissolveDelay.additional_dissolve_delay_seconds,
+      },
+    };
+  }
+  if ("JoinCommunityFund" in operation) {
+    return operation;
+  }
+  if ("SetDissolveTimestamp" in operation) {
+    const setDissolveTimestamp = operation.SetDissolveTimestamp;
+    return {
+      SetDissolveTimestamp: {
+        dissolveTimestampSeconds:
+          setDissolveTimestamp.dissolve_timestamp_seconds,
+      },
+    };
+  }
+  throw new UnsupportedValueError(operation);
+};
 
-  private toAccountIdentifier(
-    accountIdentifier: RawAccountIdentifier
-  ): AccountIdentifier {
-    return accountIdentifierFromBytes(new Uint8Array(accountIdentifier.hash));
+const toChange = (change: RawChange): Change => {
+  if ("ToRemove" in change) {
+    return {
+      ToRemove: toNodeProvider(change.ToRemove),
+    };
+  }
+  if ("ToAdd" in change) {
+    return {
+      ToAdd: toNodeProvider(change.ToAdd),
+    };
+  }
+  throw new UnsupportedValueError(change);
+};
+
+const toNodeProvider = (nodeProvider: RawNodeProvider): NodeProvider => {
+  return {
+    id: nodeProvider.id.length ? nodeProvider.id[0].toString() : undefined,
+    rewardAccount: nodeProvider.reward_account.length
+      ? toAccountIdentifier(nodeProvider.reward_account[0])
+      : undefined,
+  };
+};
+
+const toAmount = (amount: RawAmount): E8s => {
+  return amount.e8s;
+};
+
+const toAccountIdentifier = (
+  accountIdentifier: RawAccountIdentifier
+): AccountIdentifier =>
+  accountIdentifierFromBytes(new Uint8Array(accountIdentifier.hash));
+
+const toRewardMode = (rewardMode: RawRewardMode): RewardMode => {
+  if ("RewardToNeuron" in rewardMode) {
+    return {
+      RewardToNeuron: {
+        dissolveDelaySeconds: rewardMode.RewardToNeuron.dissolve_delay_seconds,
+      },
+    };
+  } else if ("RewardToAccount" in rewardMode) {
+    return {
+      RewardToAccount: {
+        toAccount:
+          rewardMode.RewardToAccount.to_account != undefined &&
+          rewardMode.RewardToAccount.to_account.length
+            ? toAccountIdentifier(rewardMode.RewardToAccount.to_account[0])
+            : undefined,
+      },
+    };
+  } else {
+    // Ensures all cases are covered at compile-time.
+    throw new UnsupportedValueError(rewardMode);
+  }
+};
+
+const toClaimOrRefreshBy = (by: RawBy): By => {
+  if ("NeuronIdOrSubaccount" in by) {
+    return {
+      NeuronIdOrSubaccount: {},
+    };
+  } else if ("Memo" in by) {
+    return {
+      Memo: by.Memo,
+    };
+  } else if ("MemoAndController" in by) {
+    return {
+      MemoAndController: {
+        memo: by.MemoAndController.memo,
+        controller: by.MemoAndController.controller.length
+          ? by.MemoAndController.controller[0]
+          : undefined,
+      },
+    };
+  } else {
+    // Ensures all cases are covered at compile-time.
+    throw new UnsupportedValueError(by);
+  }
+};
+
+// eslint-disable-next-line
+const throwUnrecognisedTypeError = (name: string, value: any): Error => {
+  return new Error(`Unrecognised ${name} type - ${JSON.stringify(value)}`);
+};
+
+export const toProposalInfo = (
+  proposalInfo: RawProposalInfo
+): ProposalInfo => ({
+  id: proposalInfo.id.length ? toNeuronId(proposalInfo.id[0]) : undefined,
+  ballots: proposalInfo.ballots.map((b) => toBallot(b[0], b[1])),
+  rejectCost: proposalInfo.reject_cost_e8s,
+  proposalTimestampSeconds: proposalInfo.proposal_timestamp_seconds,
+  rewardEventRound: proposalInfo.reward_event_round,
+  failedTimestampSeconds: proposalInfo.failed_timestamp_seconds,
+  decidedTimestampSeconds: proposalInfo.decided_timestamp_seconds,
+  proposal: proposalInfo.proposal.length
+    ? toProposal(proposalInfo.proposal[0])
+    : undefined,
+  proposer: proposalInfo.proposer.length
+    ? toNeuronId(proposalInfo.proposer[0])
+    : undefined,
+  latestTally: proposalInfo.latest_tally.length
+    ? toTally(proposalInfo.latest_tally[0])
+    : undefined,
+  executedTimestampSeconds: proposalInfo.executed_timestamp_seconds,
+  topic: proposalInfo.topic,
+  status: proposalInfo.status,
+  rewardStatus: proposalInfo.reward_status,
+});
+
+export const toArrayOfNeuronInfo = (
+  { neuron_infos, full_neurons }: RawListNeuronsResponse,
+  principal: Principal
+): Array<NeuronInfo> =>
+  neuron_infos.map(([id, neuronInfo]) =>
+    toNeuronInfo(
+      id,
+      principal.toString(),
+      neuronInfo,
+      full_neurons.find((neuron) => neuron.id.length && neuron.id[0].id === id)
+    )
+  );
+
+export const toListProposalsResponse = ({
+  proposal_info,
+}: RawListProposalInfoResponse): ListProposalsResponse => ({
+  proposals: proposal_info.map(toProposalInfo),
+});
+
+export const toKnownNeuron = ({
+  id,
+  known_neuron_data,
+}: RawKnownNeuron): KnownNeuron => {
+  return {
+    id: id[0]?.id ?? BigInt(0),
+    name: known_neuron_data[0]?.name ?? "",
+    description: known_neuron_data[0]?.description[0] ?? "",
+  };
+};
+
+/* Protobuf is not supported yet.
+export const toSpawnResponse = (
+  response: PbManageNeuronResponse
+): SpawnResponse => {
+  const createdNeuronId = response.getSpawn()?.getCreatedNeuronId();
+
+  if (!createdNeuronId) {
+    throw throwUnrecognisedTypeError("response", response);
   }
 
-  private toRewardMode(rewardMode: RawRewardMode): RewardMode {
-    if ("RewardToNeuron" in rewardMode) {
-      return {
-        RewardToNeuron: {
-          dissolveDelaySeconds:
-            rewardMode.RewardToNeuron.dissolve_delay_seconds,
-        },
-      };
-    } else if ("RewardToAccount" in rewardMode) {
-      return {
-        RewardToAccount: {
-          toAccount:
-            rewardMode.RewardToAccount.to_account != undefined &&
-            rewardMode.RewardToAccount.to_account.length
-              ? this.toAccountIdentifier(
-                  rewardMode.RewardToAccount.to_account[0]
-                )
-              : undefined,
-        },
-      };
-    } else {
-      // Ensures all cases are covered at compile-time.
-      throw new UnsupportedValueError(rewardMode);
+  return {
+    createdNeuronId: BigInt(createdNeuronId.getId()),
+  };
+};
+*/
+
+export const toSplitResponse = (
+  response: RawManageNeuronResponse
+): NeuronId => {
+  const command = response.command.length ? response.command[0] : undefined;
+
+  if (command && "Split" in command) {
+    const createdNeuronId = command.Split.created_neuron_id;
+    if (createdNeuronId.length) {
+      return createdNeuronId[0].id;
     }
   }
+  throw throwUnrecognisedTypeError("response", response);
+};
 
-  private toClaimOrRefreshBy(by: RawBy): By {
-    if ("NeuronIdOrSubaccount" in by) {
-      return {
-        NeuronIdOrSubaccount: {},
-      };
-    } else if ("Memo" in by) {
-      return {
-        Memo: by.Memo,
-      };
-    } else if ("MemoAndController" in by) {
-      return {
-        MemoAndController: {
-          memo: by.MemoAndController.memo,
-          controller: by.MemoAndController.controller.length
-            ? by.MemoAndController.controller[0]
-            : undefined,
-        },
-      };
-    } else {
-      // Ensures all cases are covered at compile-time.
-      throw new UnsupportedValueError(by);
-    }
+/* Protobuf is not supported yet.
+export const toDisburseResponse = (
+  response: PbManageNeuronResponse
+): DisburseResponse => {
+  const blockHeight = response.getDisburse()?.getTransferBlockHeight();
+
+  if (!blockHeight) {
+    throw throwUnrecognisedTypeError("response", response);
   }
 
-  // eslint-disable-next-line
-  private throwUnrecognisedTypeError(name: string, value: any): Error {
-    return new Error(`Unrecognised ${name} type - ${JSON.stringify(value)}`);
+  return {
+    transferBlockHeight: BigInt(blockHeight),
+  };
+};
+*/
+
+export const toDisburseToNeuronResult = (
+  response: RawManageNeuronResponse
+): DisburseToNeuronResponse => {
+  const command = response.command;
+  if (
+    command.length &&
+    "Spawn" in command[0] &&
+    command[0].Spawn.created_neuron_id.length
+  ) {
+    return {
+      createdNeuronId: command[0].Spawn.created_neuron_id[0].id,
+    };
   }
-}
+  throw throwUnrecognisedTypeError("response", response);
+};
+
+export const toClaimOrRefreshNeuronResponse = (
+  response: RawManageNeuronResponse
+): Option<NeuronId> => {
+  const command = response.command;
+  if (command.length && "ClaimOrRefresh" in command[0]) {
+    return command[0].ClaimOrRefresh.refreshed_neuron_id.length
+      ? command[0].ClaimOrRefresh.refreshed_neuron_id[0].id
+      : undefined;
+  }
+  throw throwUnrecognisedTypeError("response", response);
+};
+
+/* Protobuf is not supported yet.
+export const toMergeMaturityResponse = (
+  response: PbManageNeuronResponse
+): MergeMaturityResponse => {
+  const error = response.getError();
+  if (error) {
+    throw error.getErrorMessage();
+  }
+
+  const mergeMaturityResponse = response.getMergeMaturity();
+  if (mergeMaturityResponse) {
+    return {
+      mergedMaturityE8s: BigInt(mergeMaturityResponse.getMergedMaturityE8s()),
+      newStakeE8s: BigInt(mergeMaturityResponse.getNewStakeE8s()),
+    };
+  }
+
+  throw throwUnrecognisedTypeError("response", response);
+};
+*/
+
+export const toMakeProposalResponse = (
+  response: RawManageNeuronResponse
+): MakeProposalResponse => {
+  const command = response.command;
+  if (
+    command.length &&
+    "MakeProposal" in command[0] &&
+    command[0].MakeProposal.proposal_id.length
+  ) {
+    return {
+      proposalId: command[0].MakeProposal.proposal_id[0].id,
+    };
+  }
+  throw throwUnrecognisedTypeError("response", response);
+};

--- a/src/canisters/governance/response.converters.ts
+++ b/src/canisters/governance/response.converters.ts
@@ -592,14 +592,9 @@ const toClaimOrRefreshBy = (by: RawBy): By => {
   }
 };
 
+// prettier-ignore
 // eslint-disable-next-line
-const throwUnrecognisedTypeError = ({
-  name,
-  value,
-}: {
-  name: string;
-  value: any;
-}): Error => {
+const throwUnrecognisedTypeError = ({ name, value, }: { name: string; value: any; }): Error => {
   return new Error(`Unrecognised ${name} type - ${JSON.stringify(value)}`);
 };
 

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -4,9 +4,9 @@ import { sha256 } from "js-sha256";
 import randomBytes from "randombytes";
 import { idlFactory as certifiedIdlFactory } from "../candid/governance.certified.idl";
 import { GovernanceService, idlFactory } from "../candid/governance.idl";
-import { ProposalInfo as RawProposalInfo } from "../candid/governanceTypes";
+import {ListProposalInfo, ProposalInfo as RawProposalInfo} from '../candid/governanceTypes';
 import { AccountIdentifier, SubAccount } from "./account_identifier";
-import { RequestConverters } from "./canisters/governance/request.converters";
+import {fromListNeurons, fromListProposalsRequest} from './canisters/governance/request.converters';
 import { ResponseConverters } from "./canisters/governance/response.converters";
 import { MAINNET_GOVERNANCE_CANISTER_ID } from "./constants/canister_ids";
 import { E8S_PER_ICP } from "./constants/constants";
@@ -39,13 +39,11 @@ export class GovernanceCanister {
     private readonly canisterId: Principal,
     private readonly service: GovernanceService,
     private readonly certifiedService: GovernanceService,
-    private readonly requestConverters: RequestConverters,
     private readonly responseConverters: ResponseConverters
   ) {
     this.canisterId = canisterId;
     this.service = service;
     this.certifiedService = certifiedService;
-    this.requestConverters = requestConverters;
     this.responseConverters = responseConverters;
   }
 
@@ -67,14 +65,12 @@ export class GovernanceCanister {
         canisterId,
       });
 
-    const requestConverters = new RequestConverters();
     const responseConverters = new ResponseConverters();
 
     return new GovernanceCanister(
       canisterId,
       service,
       certifiedService,
-      requestConverters,
       responseConverters
     );
   }
@@ -98,7 +94,7 @@ export class GovernanceCanister {
     principal: Principal;
     neuronIds?: NeuronId[];
   }): Promise<NeuronInfo[]> => {
-    const rawRequest = this.requestConverters.fromListNeurons(neuronIds);
+    const rawRequest = fromListNeurons(neuronIds);
     const raw_response = await this.getGovernanceService(
       certified
     ).list_neurons(rawRequest);
@@ -140,7 +136,7 @@ export class GovernanceCanister {
     request: ListProposalsRequest;
     certified?: boolean;
   }): Promise<ListProposalsResponse> => {
-    const rawRequest = this.requestConverters.fromListProposalsRequest(request);
+    const rawRequest: ListProposalInfo = fromListProposalsRequest(request);
     const rawResponse = await this.getGovernanceService(
       certified
     ).list_proposals(rawRequest);


### PR DESCRIPTION
# Motivation

Governance converters are classes that actually hold no states and mixes functions and methods.

# Changes

- removes the classes, because stateless and have no particular purpose
- transform Governance converters (`response.converter.ts` and `request.converter.ts`) methods to functions
- few utilities functions refactored to use objects as parameters instead of comma separated list

