### PR TITLE
Enter a valid schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: CI Checks
 
 on:
   schedule:
-  #- cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 jobs:
   formatting:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Motivation
The workflow view is broken, as can be seen here:  https://github.com/dfinity/nns-js/actions/runs/1921133150

The problem is that the schedule is commented out, and that makes the file invalid.

The schedule is commented out to prevent this from running until an org npm key is installed, as I have no power to create one myself.  This same goal can and has now been achieved by disabling the workflow in the GitHub UI, as [per the GitHub docs.](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow).

# Changes
* Uncomment the schedule

# Tests
Workflows are rendered correctly on this PR.