### PR TITLE
feat: neurons utils voted, not voted and ineligible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from "./types/governance";
 export * from "./types/governance_converters";
 export * from "./types/icp";
 export * from "./types/ledger";
+export * from "./utils/neurons.utils";

--- a/src/utils/neurons.utils.spec.ts
+++ b/src/utils/neurons.utils.spec.ts
@@ -1,0 +1,182 @@
+import { NeuronInfo, ProposalInfo, Vote } from "../types/governance_converters";
+import {
+  ineligibleNeurons,
+  notVotedNeurons,
+  votedNeurons,
+} from "./neurons.utils";
+
+describe("neurons-utils", () => {
+  const proposalTimestampSeconds = BigInt(new Date().getTime());
+
+  const proposalId = BigInt(3);
+  const proposalNeuronId = BigInt(1);
+
+  const proposal: ProposalInfo = {
+    id: proposalId,
+    proposalTimestampSeconds,
+    ballots: [
+      {
+        neuronId: proposalNeuronId,
+        vote: Vote.YES,
+        votingPower: BigInt(1),
+      },
+    ],
+  } as unknown as ProposalInfo;
+
+  const ineligibleNeuronsDate: NeuronInfo[] = [
+    {
+      createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
+      neuronId: proposalNeuronId,
+      recentBallots: [],
+    } as unknown as NeuronInfo,
+  ];
+
+  const ineligibleNeuronsTooShort: NeuronInfo[] = [
+    {
+      createdTimestampSeconds: proposalTimestampSeconds - BigInt(1),
+      neuronId: BigInt(2),
+      recentBallots: [],
+    } as unknown as NeuronInfo,
+  ];
+
+  const eligibleNeuronsDate: NeuronInfo[] = [
+    {
+      createdTimestampSeconds: proposalTimestampSeconds - BigInt(1),
+      neuronId: proposalNeuronId,
+      recentBallots: [],
+    } as unknown as NeuronInfo,
+  ];
+
+  it("should has an ineligible neuron because created after proposal", () => {
+    const ineligible = ineligibleNeurons({
+      proposal,
+      neurons: ineligibleNeuronsDate,
+    });
+    expect(ineligible.length).toEqual(1);
+  });
+
+  it("should has an ineligible neuron because dissolve too short", () => {
+    const ineligible = ineligibleNeurons({
+      proposal,
+      neurons: ineligibleNeuronsTooShort,
+    });
+    expect(ineligible.length).toEqual(1);
+  });
+
+  it("should has not ineligible neuron because empty", () => {
+    const ineligible = ineligibleNeurons({ proposal, neurons: [] });
+    expect(ineligible.length).toEqual(0);
+  });
+
+  it("should not have not voted neurons because ineligible", () => {
+    let notVoted = notVotedNeurons({
+      proposal,
+      neurons: ineligibleNeuronsDate,
+    });
+    expect(notVoted.length).toEqual(0);
+
+    notVoted = notVotedNeurons({
+      proposal,
+      neurons: ineligibleNeuronsTooShort,
+    });
+    expect(notVoted.length).toEqual(0);
+  });
+
+  it("should not have not voted neurons because already voted", () => {
+    const notVoted = notVotedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [
+            {
+              proposalId,
+              vote: Vote.NO,
+            },
+          ],
+        },
+      ],
+    });
+    expect(notVoted.length).toEqual(0);
+  });
+
+  it("should have not voted neurons because not yet voted", () => {
+    const notVoted = notVotedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [
+            {
+              proposalId: BigInt(4),
+              vote: Vote.NO,
+            },
+          ],
+        },
+      ],
+    });
+    expect(notVoted.length).toEqual(1);
+  });
+
+  it("should have not voted neurons because never voted", () => {
+    const notVoted = notVotedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+        },
+      ],
+    });
+    expect(notVoted.length).toEqual(1);
+  });
+
+  it("should not have voted neurons because not voted", () => {
+    const voted = votedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [
+            {
+              proposalId: BigInt(4),
+              vote: Vote.NO,
+            },
+          ],
+        },
+      ],
+    });
+    expect(voted.length).toEqual(0);
+  });
+
+  it("should not have voted neurons because never voted", () => {
+    const voted = votedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+        },
+      ],
+    });
+    expect(voted.length).toEqual(0);
+  });
+
+  it("should have voted neurons because has voted", () => {
+    const voted = votedNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [
+            {
+              proposalId,
+              vote: Vote.NO,
+            },
+          ],
+        },
+      ],
+    });
+    expect(voted.length).toEqual(1);
+  });
+});

--- a/src/utils/neurons.utils.ts
+++ b/src/utils/neurons.utils.ts
@@ -19,8 +19,7 @@ const voteForProposal = ({
   }
 
   const ballot: BallotInfo | undefined = recentBallots.find(
-    ({ proposalId: id }: BallotInfo) =>
-      proposalId !== undefined && id === proposalId
+    ({ proposalId: id }: BallotInfo) => id === proposalId
   );
   return ballot?.vote;
 };

--- a/src/utils/neurons.utils.ts
+++ b/src/utils/neurons.utils.ts
@@ -1,0 +1,78 @@
+import type {
+  Ballot,
+  BallotInfo,
+  NeuronInfo,
+  ProposalId,
+  ProposalInfo,
+  Vote,
+} from "../types/governance_converters";
+
+const voteForProposal = ({
+  recentBallots,
+  proposalId,
+}: {
+  recentBallots: BallotInfo[];
+  proposalId: ProposalId | undefined;
+}): Vote | undefined => {
+  const ballot: BallotInfo | undefined = recentBallots.find(
+    ({ proposalId: id }: BallotInfo) =>
+      proposalId !== undefined && id === proposalId
+  );
+  return ballot?.vote;
+};
+
+export const ineligibleNeurons = ({
+  neurons,
+  proposal,
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): NeuronInfo[] => {
+  const { ballots, proposalTimestampSeconds } = proposal;
+
+  return neurons.filter(({ createdTimestampSeconds, neuronId }: NeuronInfo) => {
+    const createdSinceProposal: boolean =
+      createdTimestampSeconds > proposalTimestampSeconds;
+
+    const dissolveTooShort: boolean =
+      ballots.find(
+        ({ neuronId: ballotNeuronId }: Ballot) => ballotNeuronId === neuronId
+      ) === undefined;
+
+    return createdSinceProposal || dissolveTooShort;
+  });
+};
+
+export const notVotedNeurons = ({
+  neurons,
+  proposal,
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): NeuronInfo[] => {
+  const { id: proposalId } = proposal;
+
+  return neurons.filter(
+    ({ recentBallots, neuronId }: NeuronInfo) =>
+      voteForProposal({ recentBallots, proposalId }) === undefined &&
+      ineligibleNeurons({ neurons, proposal }).find(
+        ({ neuronId: ineligibleNeuronId }: NeuronInfo) =>
+          ineligibleNeuronId === neuronId
+      ) === undefined
+  );
+};
+
+export const votedNeurons = ({
+  neurons,
+  proposal,
+}: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): NeuronInfo[] => {
+  const { id: proposalId } = proposal;
+
+  return neurons.filter(
+    ({ recentBallots }: NeuronInfo) =>
+      voteForProposal({ recentBallots, proposalId }) !== undefined
+  );
+};

--- a/src/utils/neurons.utils.ts
+++ b/src/utils/neurons.utils.ts
@@ -14,6 +14,10 @@ const voteForProposal = ({
   recentBallots: BallotInfo[];
   proposalId: ProposalId | undefined;
 }): Vote | undefined => {
+  if (!proposalId) {
+    return undefined;
+  }
+
   const ballot: BallotInfo | undefined = recentBallots.find(
     ({ proposalId: id }: BallotInfo) =>
       proposalId !== undefined && id === proposalId


### PR DESCRIPTION
# Motivation

Re-implement and expose neurons' utilities to filter ineligible, voted and not voted neurons.

These functions are currently implemented within the UI of the nns-dapp Flutter app.

See [lib/ui/proposals/proposal_detail_widget.dart](https://github.com/dfinity/nns-dapp/blob/62d66de3c3e1fbf4957c79cf50be489307555689/frontend/dart/lib/ui/proposals/proposal_detail_widget.dart#L55)

# Changes

- add utilities `ineligibleNeurons`, `notVotedNeurons` and `votedNeurons`
- expose the `neurons.utils.ts` to any user of `nns-js` (through an export in `index.ts`)

