### PR TITLE
Correct name of the nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: CI Checks
+name: Nightly Publication
 
 on:
   schedule:


### PR DESCRIPTION
# Motivation
The name of the nightly build was left teh same as the normal checking workflow by mistake.  This is confusing.

# Changes
* Give the nightly build an appropriate name

# Tests
None required