### PR TITLE
The proto files on main should already be up to date

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,12 @@ name: Nightly Publication
 on:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - nightly
+
 jobs:
-  formatting:
+  publish:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build nightly
         run: ./scripts/build-nightly
+      - name: Set up npm
+        run: printf "%s\n" email=github-action@dfinity.org always-auth=true >> .npmrc
       - name: Publish
         run: npm publish --tag nightly
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build nightly
         run: ./scripts/build-nightly
       - name: Set up npm
-        run: printf "%s\n" email=github-action@dfinity.org always-auth=true >> .npmrc
+        run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
         run: npm publish --tag nightly
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,9 +3,6 @@ name: Nightly Publication
 on:
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - nightly
 
 jobs:
   publish:

--- a/scripts/build-nightly
+++ b/scripts/build-nightly
@@ -9,7 +9,6 @@ node -e 'fs=require("fs");n="package.json";e={encoding:"utf8"};x = JSON.parse(fs
 npm install
 
 : Now we can build
-npm run update_proto
 npm run build
 : Create the release tarball
 npm pack


### PR DESCRIPTION
# Motivation
The nightly build failed because protoc was not installed.  Protoc should not need to be called because the protocol buffer derived files _should_ already be up to date.

# Changes
* Do not compile the protoc files.
* Set up npm profile as required to publish

# Tests
This has been run by adding an on-push rule for this branch, pushing, then removing the rule.  See: https://github.com/dfinity/nns-js/actions/workflows/nightly.yml