### PR TITLE
Add test for protobuf files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -72,7 +72,7 @@ jobs:
       #  run: git diff --exit-code
 
   build:
-    needs: [ build-candid, build-protobuf ]
+    needs: [build-candid, build-protobuf]
     runs-on: ubuntu-20.04
 
     steps:
@@ -111,5 +111,5 @@ jobs:
     needs: ["formatting", "build", "lint", "test"]
     runs-on: ubuntu-20.04
     steps:
-       - name: Cleared for merging
-         run: echo OK
+      - name: Cleared for merging
+        run: echo OK

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install protoc
-        run: apt-get install protobuf-compiler
+        run: sudo apt-get install protobuf-compiler
       - name: Compile protobuf
         run: npm run update_proto
       - name: Verify that there are no changes to the compiled did files

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Check the protoc installer
+        run: ./scripts/install-protoc --help
       - name: Install protoc
         run: sudo ./scripts/install-protoc
       - name: Install ts dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
           # the pushing fail
           pull_strategy: "NO-PULL"
 
-  build:
+  build-candid:
     runs-on: ubuntu-20.04
 
     steps:
@@ -54,6 +54,31 @@ jobs:
         run: ./scripts/compile-idl-js
       - name: Verify that there are no changes to the compiled did files
         run: git diff --exit-code
+
+  build-protobuf:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install protoc
+        run: apt-get install protobuf-compiler
+      - name: Compile protobuf
+        run: npm run update_proto
+      - name: Verify that there are no changes to the compiled did files
+        run: git diff --exit-code
+
+  build:
+    needs: [ "build-candid", build-protobuf ]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
 
   lint:
     runs-on: ubuntu-20.04
@@ -78,3 +103,10 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
+
+  may-merge:
+    needs: ["formatting", "build", "lint", "test"]
+    runs-on: ubuntu-20.04
+    steps:
+       - name: Cleared for merging
+         run: echo OK

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,6 +63,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install protoc
         run: sudo apt-get install protobuf-compiler
+      - name: Install ts dependencies
+        run: npm ci
       - name: Compile protobuf
         run: npm run update_proto
       - name: Verify that there are no changes to the compiled did files

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install ts dependencies
         run: npm ci
       - name: Compile protobuf
-        run: npm run update_proto
+        run: npm run protoc
       # TODO: Add a check that htere are no changes once this actually passes:
       #- name: Verify that there are no changes to the compiled proto files
       #  run: git diff --exit-code

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install protoc
-        run: sudo apt-get install protobuf-compiler
+        run: sudo ./scripts/install-protoc
       - name: Install ts dependencies
         run: npm ci
       - name: Compile protobuf

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,11 +67,12 @@ jobs:
         run: npm ci
       - name: Compile protobuf
         run: npm run update_proto
-      - name: Verify that there are no changes to the compiled did files
+      - name: Verify that there are no changes to the compiled proto files
         run: git diff --exit-code
 
   build:
-    needs: [ "build-candid", build-protobuf ]
+    # TODO: Add build-protobuf once it passes.
+    needs: [ build-candid ]
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,12 +67,12 @@ jobs:
         run: npm ci
       - name: Compile protobuf
         run: npm run update_proto
-      - name: Verify that there are no changes to the compiled proto files
-        run: git diff --exit-code
+      # TODO: Add a check that htere are no changes once this actually passes:
+      #- name: Verify that there are no changes to the compiled proto files
+      #  run: git diff --exit-code
 
   build:
-    # TODO: Add build-protobuf once it passes.
-    needs: [ build-candid ]
+    needs: [ build-candid, build-protobuf ]
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,9 +69,8 @@ jobs:
         run: npm ci
       - name: Compile protobuf
         run: npm run protoc
-      # TODO: Add a check that htere are no changes once this actually passes:
-      #- name: Verify that there are no changes to the compiled proto files
-      #  run: git diff --exit-code
+      - name: Verify that there are no changes to the compiled proto files
+        run: git diff --exit-code
 
   build:
     needs: [build-candid, build-protobuf]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
     "prepare": "npm run build",
-    "update_proto": "bash ./scripts/update_proto.sh"
+    "protoc": "bash ./scripts/update_proto.sh"
   },
   "dependencies": {
     "@dfinity/agent": "^0.10.3",

--- a/proto/base_types_pb.js
+++ b/proto/base_types_pb.js
@@ -13,7 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() {
+  if (this) { return this; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  if (typeof self !== 'undefined') { return self; }
+  return Function('return this')();
+}.call(null));
 
 var google_protobuf_descriptor_pb = require('google-protobuf/google/protobuf/descriptor_pb.js');
 goog.object.extend(proto, google_protobuf_descriptor_pb);

--- a/proto/ledger_pb.js
+++ b/proto/ledger_pb.js
@@ -13,7 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() {
+  if (this) { return this; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  if (typeof self !== 'undefined') { return self; }
+  return Function('return this')();
+}.call(null));
 
 var base_types_pb = require('./base_types_pb.js');
 goog.object.extend(proto, base_types_pb);

--- a/scripts/install-protoc
+++ b/scripts/install-protoc
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+operating_system() {
+	case "$(uname | tr '[:upper:]' '[:lower:]')" in
+	linux) echo linux ;;
+	darwin) echo osx ;;
+	*)
+		echo "Unsupported operating system: $(uname)" >&2
+		exit 1
+		;;
+	esac
+}
+
+PROTOC_VERSION=3.19.4
+OPERATING_SYSTEM="$(operating_system)"
+PROCESSOR="$(uname -p)"
+
+install_protoc() {
+	set -euo pipefail
+
+	(($(id -u) == 0)) || {
+		echo "Please run this as root." >&2
+		exit 1
+	}
+
+	echo "Installing protoc from https://github.com/protocolbuffers/protobuf/releases/tag/${PROTOC_VERSION}"
+	pushd "$(mktemp -d)"
+	wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OPERATING_SYSTEM}-${PROCESSOR}.zip"
+	unzip protoc-3.19.4-linux-x86_64.zip
+	install -m 755 bin/protoc /usr/local/bin/protoc
+	popd
+	echo "Finished installing protoc."
+}
+check_protoc() {
+	set -euo pipefail
+	protoc --version | awk -v v="$PROTOC_VERSION" '{if ($2 != v) exit 1}'
+}
+
+check_protoc || install_protoc && check_protoc
+echo Protoc is installed:
+command -v protoc
+protoc --version

--- a/scripts/install-protoc
+++ b/scripts/install-protoc
@@ -32,7 +32,7 @@ install_protoc() {
   install -m 755 bin/protoc "${INSTALL_DIR}/bin/protoc"
   for dir in /include/google/protobuf /include/google/protobuf/compiler; do
     install -d "${INSTALL_DIR}${dir}"
-    install -t "${INSTALL_DIR}/include/google/protobuf" "${dir}"/*
+    install -t "${INSTALL_DIR}/include/google/protobuf" ".${dir}"/*
   done
   popd
   echo "Finished installing protoc."

--- a/scripts/install-protoc
+++ b/scripts/install-protoc
@@ -37,6 +37,19 @@ check_protoc() {
 	protoc --version | awk -v v="$PROTOC_VERSION" '{if ($2 != v) exit 1}'
 }
 
+[[ "$1" != "--help" ]] || {
+	cat <<-EOF
+		Installs a specific version of protoc, the protocol buffer compiler.
+
+		Slightly different versions of protoc can produce large changes in output.
+		The differences MAY be just formatting but this is hard to confirm.
+
+		To ensure that we have consistent, reproducible builds we therefore
+		specify the exact version of protoc to be installed.
+	EOF
+	exit 0
+}
+
 check_protoc || install_protoc && check_protoc
 echo Protoc is installed:
 command -v protoc

--- a/scripts/install-protoc
+++ b/scripts/install-protoc
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 operating_system() {
-	case "$(uname | tr '[:upper:]' '[:lower:]')" in
-	linux) echo linux ;;
-	darwin) echo osx ;;
-	*)
-		echo "Unsupported operating system: $(uname)" >&2
-		exit 1
-		;;
-	esac
+  case "$(uname | tr '[:upper:]' '[:lower:]')" in
+  linux) echo linux ;;
+  darwin) echo osx ;;
+  *)
+    echo "Unsupported operating system: $(uname)" >&2
+    exit 1
+    ;;
+  esac
 }
 
 PROTOC_VERSION=3.19.4
@@ -18,32 +18,32 @@ PROCESSOR="$(uname -p)"
 INSTALL_DIR="/usr/local"
 
 install_protoc() {
-	set -euo pipefail
+  set -euo pipefail
 
-	(($(id -u) == 0)) || {
-		echo "Please run this as root." >&2
-		exit 1
-	}
+  (($(id -u) == 0)) || {
+    echo "Please run this as root." >&2
+    exit 1
+  }
 
-	echo "Installing protoc from https://github.com/protocolbuffers/protobuf/releases/tag/${PROTOC_VERSION}"
-	pushd "$(mktemp -d)"
-	wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OPERATING_SYSTEM}-${PROCESSOR}.zip"
-	unzip protoc-3.19.4-linux-x86_64.zip
-	install -m 755 bin/protoc "${INSTALL_DIR}/bin/protoc"
-	for dir in /include/google/protobuf /include/google/protobuf/compiler ; do
-		install -d "${INSTALL_DIR}${dir}"
-		install -t "${INSTALL_DIR}/include/google/protobuf" "${dir}"/*
-	done
-	popd
-	echo "Finished installing protoc."
+  echo "Installing protoc from https://github.com/protocolbuffers/protobuf/releases/tag/${PROTOC_VERSION}"
+  pushd "$(mktemp -d)"
+  wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OPERATING_SYSTEM}-${PROCESSOR}.zip"
+  unzip protoc-3.19.4-linux-x86_64.zip
+  install -m 755 bin/protoc "${INSTALL_DIR}/bin/protoc"
+  for dir in /include/google/protobuf /include/google/protobuf/compiler; do
+    install -d "${INSTALL_DIR}${dir}"
+    install -t "${INSTALL_DIR}/include/google/protobuf" "${dir}"/*
+  done
+  popd
+  echo "Finished installing protoc."
 }
 check_protoc() {
-	set -euo pipefail
-	protoc --version | awk -v v="$PROTOC_VERSION" '{if ($2 != v) exit 1}'
+  set -euo pipefail
+  protoc --version | awk -v v="$PROTOC_VERSION" '{if ($2 != v) exit 1}'
 }
 
 [[ "${1:-}" != "--help" ]] || {
-	cat <<-EOF
+  cat <<-EOF
 		Installs a specific version of protoc, the protocol buffer compiler.
 
 		Slightly different versions of protoc can produce large changes in output.
@@ -52,7 +52,7 @@ check_protoc() {
 		To ensure that we have consistent, reproducible builds we therefore
 		specify the exact version of protoc to be installed.
 	EOF
-	exit 0
+  exit 0
 }
 
 check_protoc 2>/dev/null || install_protoc && check_protoc

--- a/scripts/install-protoc
+++ b/scripts/install-protoc
@@ -15,6 +15,7 @@ operating_system() {
 PROTOC_VERSION=3.19.4
 OPERATING_SYSTEM="$(operating_system)"
 PROCESSOR="$(uname -p)"
+INSTALL_DIR="/usr/local"
 
 install_protoc() {
 	set -euo pipefail
@@ -28,7 +29,11 @@ install_protoc() {
 	pushd "$(mktemp -d)"
 	wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OPERATING_SYSTEM}-${PROCESSOR}.zip"
 	unzip protoc-3.19.4-linux-x86_64.zip
-	install -m 755 bin/protoc /usr/local/bin/protoc
+	install -m 755 bin/protoc "${INSTALL_DIR}/bin/protoc"
+	for dir in /include/google/protobuf /include/google/protobuf/compiler ; do
+		install -d "${INSTALL_DIR}${dir}"
+		install -t "${INSTALL_DIR}/include/google/protobuf" "${dir}"/*
+	done
 	popd
 	echo "Finished installing protoc."
 }
@@ -37,7 +42,7 @@ check_protoc() {
 	protoc --version | awk -v v="$PROTOC_VERSION" '{if ($2 != v) exit 1}'
 }
 
-[[ "$1" != "--help" ]] || {
+[[ "${1:-}" != "--help" ]] || {
 	cat <<-EOF
 		Installs a specific version of protoc, the protocol buffer compiler.
 
@@ -50,7 +55,7 @@ check_protoc() {
 	exit 0
 }
 
-check_protoc || install_protoc && check_protoc
+check_protoc 2>/dev/null || install_protoc && check_protoc
 echo Protoc is installed:
 command -v protoc
 protoc --version


### PR DESCRIPTION
# Motivation
protobuf builds are not currently tested in CI  That is an omission that should be addressed.

# Changes
* Add a separate test for protobuf builds.
* Organize the tests a bit:
  * The "build" test was just testing the candid build, so was misleading.  It is renamed and there is a new build test.
  * Added a new "may-merge" target, similar to that discussed for nns-dapp, to make it clearer what the merge requirements are by not hiding the merge requirements away as an invisible list in the admin panel.
  * The workflow now looks like this:  ![Screenshot from 2022-03-04 11-47-11](https://user-images.githubusercontent.com/5982633/156749604-fc89a8c2-3969-4c52-adf8-b7bcfaf91e60.png)
* Install a specific version of protoc.
* Rename the proto build command to `npm run protoc` - the original name is unnecessarily long.
* The compiled proto artifacts were slightly out of date; these have been updated.

# Future (not in this PR)
* Update the branch protection rules to use just may-merge from that workflow.

# Tests
See the CI results for this PR