### PR TITLE
feat: unify the governance naming of the functions

### DIFF
--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -88,7 +88,7 @@ describe("GovernanceCanister.listKnownNeurons", () => {
     expect(res.map((n) => Number(n.id))).toEqual([100, 200, 300, 400]);
   });
 
-  describe("getProposalInfo", () => {
+  describe("getProposal", () => {
     it("should fetch and convert single ProposalInfo", async () => {
       const service = mock<GovernanceService>();
       const governance = GovernanceCanister.create({
@@ -172,7 +172,7 @@ describe("GovernanceCanister.listKnownNeurons", () => {
     expect(response).toBeInstanceOf(InsufficientAmount);
   });
 
-  it("gets user neurons", async () => {
+  it("list user neurons", async () => {
     const one = BigInt(1);
     const mockNeuronInfo: NeuronInfo = {
       dissolve_delay_seconds: one,

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -105,7 +105,7 @@ describe("GovernanceCanister.listKnownNeurons", () => {
       service.get_proposal_info.mockResolvedValue(
         Promise.resolve([rawProposal])
       );
-      const response = await governance.getProposalInfo({
+      const response = await governance.getProposal({
         proposalId: BigInt(1),
       });
 
@@ -197,7 +197,7 @@ describe("GovernanceCanister.listKnownNeurons", () => {
       certifiedServiceOverride: service,
       serviceOverride: service,
     });
-    const neurons = await governance.getNeurons({
+    const neurons = await governance.listNeurons({
       certified: true,
       principal: new AnonymousIdentity().getPrincipal(),
     });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -91,7 +91,7 @@ export class GovernanceCanister {
    *
    * TODO: Decide: The library method is getNeurons but the raw method is list_neurons.  Do we want this inconsistency?
    */
-  public getNeurons = async ({
+  public listNeurons = async ({
     certified = true,
     principal,
     neuronIds,
@@ -201,7 +201,7 @@ export class GovernanceCanister {
    * If `certified` is true (default), the request is fetched as an update call, otherwise
    * it is fetched using a query call.
    */
-  public getProposalInfo = async ({
+  public getProposal = async ({
     proposalId,
     certified = true,
   }: {


### PR DESCRIPTION
# Motivation

Unify the naming of the functions.

We have `listKnownNeurons`, `listProposals` but `getNeurons`.
We have `listProposals` but `getProposalInfo`

# Changes

- `getNeurons` -> `listNeurons`
- `getProposalInfo` -> `getProposal`

# Note

This is a breaking change. Once merged and published, I'll adapt nns-dapp.
