### PR TITLE
L2-337: Set Neuron Followee

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -25,6 +25,7 @@ import {
   ClaimOrRefreshNeuronRequest,
   Command,
   DisburseToNeuronRequest,
+  FollowRequest,
   ListProposalsRequest,
   MakeProposalRequest,
   ManageNeuron,
@@ -777,6 +778,23 @@ export const toRegisterVoteRequest = ({
       RegisterVote: {
         vote,
         proposal: [{ id: proposalId }],
+      },
+    },
+  ],
+  neuron_id_or_subaccount: [],
+});
+
+export const toManageNeuronsFollowRequest = ({
+  neuronId,
+  topic,
+  followees,
+}: FollowRequest): RawManageNeuron => ({
+  id: [{ id: neuronId }],
+  command: [
+    {
+      Follow: {
+        topic,
+        followees: followees.map((followeeId) => ({ id: followeeId })),
       },
     },
   ],

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -15,6 +15,7 @@ import {
   mockNeuronInfo,
 } from "./mocks/governance.mock";
 import { InsufficientAmount } from "./types/governance";
+import { Topic } from "./types/governance_converters";
 
 describe("GovernanceCanister.listKnownNeurons", () => {
   it("populates all KnownNeuron fields correctly", async () => {
@@ -331,5 +332,67 @@ describe("GovernanceCanister.increaseDissolveDelay", () => {
     expect(service.manage_neuron).toBeCalled();
     expect("Ok" in response).toBeFalsy();
     expect("Err" in response).toBeTruthy();
+  });
+
+  describe("GovernanceCanister.setFollowees", () => {
+    it("sets followees successfully", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Follow: {} }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.setFollowees({
+        neuronId: BigInt(1),
+        topic: Topic.Governance,
+        followees: [BigInt(3), BigInt(6)],
+      });
+      expect(service.manage_neuron).toBeCalled();
+      expect("Ok" in response).toBeTruthy();
+      expect("Err" in response).toBeFalsy();
+    });
+
+    it("returns error when setFollowees fails with error", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Error: { error_message: "Some error", error_type: 1 } }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.setFollowees({
+        neuronId: BigInt(1),
+        topic: Topic.Governance,
+        followees: [BigInt(3), BigInt(6)],
+      });
+      expect(service.manage_neuron).toBeCalled();
+      expect("Ok" in response).toBeFalsy();
+      expect("Err" in response).toBeTruthy();
+    });
+
+    it("returns error when setFollowees fails unexpectetdly", async () => {
+      const serviceResponse: ManageNeuronResponse = {
+        command: [],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.setFollowees({
+        neuronId: BigInt(1),
+        topic: Topic.Governance,
+        followees: [BigInt(3), BigInt(6)],
+      });
+      expect(service.manage_neuron).toBeCalled();
+      expect("Ok" in response).toBeFalsy();
+      expect("Err" in response).toBeTruthy();
+    });
   });
 });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -13,6 +13,7 @@ import {
   fromListNeurons,
   fromListProposalsRequest,
   toIncreaseDissolveDelayRequest,
+  toManageNeuronsFollowRequest,
   toRegisterVoteRequest,
 } from "./canisters/governance/request.converters";
 import {
@@ -36,6 +37,7 @@ import {
 import {
   ClaimOrRefreshNeuronFromAccount,
   EmptyResponse,
+  FollowRequest,
   KnownNeuron,
   ListProposalsRequest,
   ListProposalsResponse,
@@ -274,6 +276,28 @@ export class GovernanceCanister {
     return {
       Err: response.Err || {
         errorMessage: "Error registering vote",
+        errorType: 0,
+      },
+    };
+  };
+
+  /**
+   * Edit neuron followees per topic
+   */
+  public setFollowees = async (
+    followRequest: FollowRequest
+  ): Promise<EmptyResponse> => {
+    const request = toManageNeuronsFollowRequest(followRequest);
+    const response = await manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+    if (response.Ok) {
+      return { Ok: null };
+    }
+    return {
+      Err: response.Err || {
+        errorMessage: "Error setting followees",
         errorType: 0,
       },
     };

--- a/src/types/governance_converters.ts
+++ b/src/types/governance_converters.ts
@@ -517,6 +517,7 @@ export interface SpawnResponse {
 }
 export type EmptyResponse = { Ok: null } | { Err: GovernanceError };
 
+// TODO: Remove, do we ever use this?
 export default interface ServiceInterface {
   getNeurons: (
     certified: boolean,

--- a/src/types/governance_converters.ts
+++ b/src/types/governance_converters.ts
@@ -517,7 +517,6 @@ export interface SpawnResponse {
 }
 export type EmptyResponse = { Ok: null } | { Err: GovernanceError };
 
-// TODO: Remove, do we ever use this?
 export default interface ServiceInterface {
   getNeurons: (
     certified: boolean,


### PR DESCRIPTION
# Motivation

Add functionality to update neuron followees.

# Changes

* New method `setFollowees` in governance canister.

# Tests

* Method test.
