### PR TITLE
L2-338: Transfer from subaccounts

### DIFF
--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -148,6 +148,36 @@ describe("GovernanceCanister.listKnownNeurons", () => {
     expect(response).toEqual(neuronId);
   });
 
+  it("creates new neuron from subaccount successfully", async () => {
+    const neuronId = BigInt(1);
+    const clainNeuronResponse: ClaimOrRefreshNeuronFromAccountResponse = {
+      result: [{ NeuronId: { id: neuronId } }],
+    };
+    const service = mock<GovernanceService>();
+    service.claim_or_refresh_neuron_from_account.mockResolvedValue(
+      clainNeuronResponse
+    );
+
+    const mockLedger = mock<LedgerCanister>();
+    mockLedger.transfer.mockImplementation(
+      jest.fn().mockResolvedValue(BigInt(1))
+    );
+
+    const governance = GovernanceCanister.create({
+      certifiedServiceOverride: service,
+    });
+    const response = await governance.stakeNeuron({
+      stake: ICP.fromString("1") as ICP,
+      principal: new AnonymousIdentity().getPrincipal(),
+      ledgerCanister: mockLedger,
+      fromSubAccountId: 1234,
+    });
+
+    expect(mockLedger.transfer).toBeCalled();
+    expect(service.claim_or_refresh_neuron_from_account).toBeCalled();
+    expect(response).toEqual(neuronId);
+  });
+
   it("returns insufficient amount errors", async () => {
     const neuronId = BigInt(1);
     const clainNeuronResponse: ClaimOrRefreshNeuronFromAccountResponse = {

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -158,10 +158,12 @@ export class GovernanceCanister {
   public stakeNeuron = async ({
     stake,
     principal,
+    fromSubAccountId,
     ledgerCanister,
   }: {
     stake: ICP;
     principal: Principal;
+    fromSubAccountId?: number;
     ledgerCanister: LedgerCanister;
   }): Promise<NeuronId | StakeNeuronError> => {
     if (stake.toE8s() < E8S_PER_ICP) {
@@ -180,8 +182,8 @@ export class GovernanceCanister {
     const response = await ledgerCanister.transfer({
       memo: nonce,
       amount: stake,
+      fromSubAccountId,
       to: accountIdentifier,
-      // TODO: Support subaccounts
     });
 
     if (typeof response !== "bigint") {

--- a/src/ledger.spec.ts
+++ b/src/ledger.spec.ts
@@ -111,4 +111,22 @@ describe("LedgerCanister.transfer", () => {
 
     expect(res).toEqual(new TxTooOld(123));
   });
+
+  it("handles subaccount", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: jest
+        .fn()
+        .mockResolvedValue(new Uint8Array(32).fill(0)),
+    });
+
+    const res = await ledger.transfer({
+      to: AccountIdentifier.fromHex(
+        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+      ),
+      amount: ICP.fromE8s(BigInt(100000)),
+      fromSubAccountId: 1234,
+    });
+
+    expect(typeof res).toEqual("bigint");
+  });
 });

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -173,8 +173,8 @@ export class LedgerCanister {
     return BigInt(PbBlockHeight.deserializeBinary(responseBytes).getHeight());
   };
 
-  private subAccountIdToSubaccount = (index: number): Subaccount => {
-    const bytes = numberToArrayBuffer(index, SUB_ACCOUNT_BYTE_LENGTH);
+  private subAccountIdToSubaccount = (subAccountId: number): Subaccount => {
+    const bytes = numberToArrayBuffer(subAccountId, SUB_ACCOUNT_BYTE_LENGTH);
     const subaccount = new Subaccount();
     subaccount.setSubAccount(new Uint8Array(bytes));
     return subaccount;

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -7,9 +7,11 @@ import {
   Memo,
   Payment,
   SendRequest,
+  Subaccount,
 } from "../proto/ledger_pb";
 import { AccountIdentifier } from "./account_identifier";
 import { MAINNET_LEDGER_CANISTER_ID } from "./constants/canister_ids";
+import { SUB_ACCOUNT_BYTE_LENGTH } from "./constants/constants";
 import { ICP } from "./icp";
 import { BlockHeight } from "./types/common";
 import {
@@ -23,6 +25,7 @@ import {
   TxTooOld,
 } from "./types/ledger";
 import { defaultAgent } from "./utils/agent.utils";
+import { numberToArrayBuffer } from "./utils/converter.utils";
 import { queryCall, updateCall } from "./utils/proto.utils";
 
 export class LedgerCanister {
@@ -86,10 +89,12 @@ export class LedgerCanister {
     to,
     amount,
     memo,
+    fromSubAccountId,
   }: {
     to: AccountIdentifier;
     amount: ICP;
     memo?: bigint;
+    fromSubAccountId?: number;
   }): Promise<BlockHeight | TransferError> => {
     const request = new SendRequest();
     request.setTo(to.toProto());
@@ -102,6 +107,12 @@ export class LedgerCanister {
       const memo = new Memo();
       memo.setMemo(memo.toString());
       request.setMemo(memo);
+    }
+
+    if (fromSubAccountId !== undefined) {
+      request.setFromSubaccount(
+        this.subAccountIdToSubaccount(fromSubAccountId)
+      );
     }
 
     const responseBytes = await this.updateFetcher(
@@ -160,5 +171,12 @@ export class LedgerCanister {
 
     // Successful tx. Return the block height.
     return BigInt(PbBlockHeight.deserializeBinary(responseBytes).getHeight());
+  };
+
+  private subAccountIdToSubaccount = (index: number): Subaccount => {
+    const bytes = numberToArrayBuffer(index, SUB_ACCOUNT_BYTE_LENGTH);
+    const subaccount = new Subaccount();
+    subaccount.setSubAccount(new Uint8Array(bytes));
+    return subaccount;
   };
 }


### PR DESCRIPTION
# Motivation

LedgerCanister#transfer and GovernanceCanister#stakeNeuron support subaccounts.

# Changes

* Add subaccount id converter to LedgerCanister.
* Add fromSubaccount to stakeNeuron.
* Add fromSubaccount to transfer.

# Tests

* Add test in Ledger Canister for subaccount.
* Add test in Governance Canister for stake neuron from subaccount.
