### PR TITLE
L2-331: Check Neuron Balances

### DIFF
--- a/src/errors/governance.errors.ts
+++ b/src/errors/governance.errors.ts
@@ -11,6 +11,7 @@ export class InsufficientAmountError extends StakeNeuronError {
   }
 }
 
+export class UnrecognizedTypeError extends Error {}
 export class GovernanceError extends Error {
   constructor(public readonly detail: GovernanceErrorDetail) {
     super();

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -459,3 +459,44 @@ describe("GovernanceCanister.increaseDissolveDelay", () => {
     });
   });
 });
+
+describe("GovernanceCanister.claimOrRefreshNeuron", () => {
+  it("successfully claims or refreshes", async () => {
+    const neuronId = BigInt(10);
+    const serviceResponse: ManageNeuronResponse = {
+      command: [
+        { ClaimOrRefresh: { refreshed_neuron_id: [{ id: neuronId }] } },
+      ],
+    };
+    const service = mock<GovernanceService>();
+    service.manage_neuron.mockResolvedValue(serviceResponse);
+
+    const governance = GovernanceCanister.create({
+      serviceOverride: service,
+    });
+    const response = await governance.claimOrRefreshNeuron({
+      neuronId,
+      by: { NeuronIdOrSubaccount: {} },
+    });
+    expect(service.manage_neuron).toBeCalled();
+  });
+
+  it("throws error if response does not match", async () => {
+    const neuronId = BigInt(10);
+    const serviceResponse: ManageNeuronResponse = {
+      command: [{ Configure: {} }],
+    };
+    const service = mock<GovernanceService>();
+    service.manage_neuron.mockResolvedValue(serviceResponse);
+
+    const governance = GovernanceCanister.create({
+      serviceOverride: service,
+    });
+    const call = () =>
+      governance.claimOrRefreshNeuron({
+        neuronId,
+        by: { NeuronIdOrSubaccount: {} },
+      });
+    expect(call).rejects.toThrowError();
+  });
+});

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -319,10 +319,7 @@ export class GovernanceCanister {
     const { command } = rawResponse;
     if (command.length && "ClaimOrRefresh" in command[0]) {
       const claim = command[0].ClaimOrRefresh;
-      if (claim.refreshed_neuron_id.length) {
-        return claim.refreshed_neuron_id[0].id;
-      }
-      return undefined;
+      return claim.refreshed_neuron_id[0]?.id;
     }
 
     throw new UnrecognizedTypeError(


### PR DESCRIPTION
# Motivation

Add `claimOrRefreshNeuron` method to Governance Canister.

# Changes

* New method `claimOrRefreshNeuron` in Governance Canister.

# Tests

* New claimOrRefreshNeuron tests
