### PR TITLE
Fix: Typo

### DIFF
--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -512,7 +512,7 @@ describe("GovernanceCanister.claimOrRefreshNeuron", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      const response = await governance.joinComunityFund(neuronId);
+      const response = await governance.joinCommunityFund(neuronId);
       expect(service.manage_neuron).toBeCalled();
     });
 
@@ -531,7 +531,7 @@ describe("GovernanceCanister.claimOrRefreshNeuron", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      const call = () => governance.joinComunityFund(neuronId);
+      const call = () => governance.joinCommunityFund(neuronId);
       expect(call).rejects.toThrow(new GovernanceError(error));
     });
   });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -234,7 +234,7 @@ export class GovernanceCanister {
    *
    * @throws {@link GovernanceError}
    */
-  public joinComunityFund = async (neuronId: NeuronId): Promise<void> => {
+  public joinCommunityFund = async (neuronId: NeuronId): Promise<void> => {
     const request = toJoinCommunityFundRequest(neuronId);
 
     return manageNeuron({


### PR DESCRIPTION
# Motivation

Fix typo in `joinComunityFund` method.

# Changes

* Write community with two "m"s.

# Tests

* Update tests.
