### PR TITLE
L2-364: Start and Stop Dissolving Neuron

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -842,3 +842,39 @@ export const toJoinCommunityFundRequest = (
   ],
   neuron_id_or_subaccount: [],
 });
+
+export const toStartDissolvingRequest = (
+  neuronId: NeuronId
+): RawManageNeuron => ({
+  id: [{ id: neuronId }],
+  command: [
+    {
+      Configure: {
+        operation: [
+          {
+            StartDissolving: {},
+          },
+        ],
+      },
+    },
+  ],
+  neuron_id_or_subaccount: [],
+});
+
+export const toStopDissolvingRequest = (
+  neuronId: NeuronId
+): RawManageNeuron => ({
+  id: [{ id: neuronId }],
+  command: [
+    {
+      Configure: {
+        operation: [
+          {
+            StopDissolving: {},
+          },
+        ],
+      },
+    },
+  ],
+  neuron_id_or_subaccount: [],
+});

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -535,4 +535,76 @@ describe("GovernanceCanister.claimOrRefreshNeuron", () => {
       expect(call).rejects.toThrow(new GovernanceError(error));
     });
   });
+
+  describe("GovernanceCanister.startDissolving", () => {
+    it("successfully starts dissolving process", async () => {
+      const neuronId = BigInt(10);
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Configure: {} }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.startDissolving(neuronId);
+      expect(service.manage_neuron).toBeCalled();
+    });
+
+    it("throws error if response is error", async () => {
+      const error: GovernanceErrorDetail = {
+        error_message: "Some error",
+        error_type: 1,
+      };
+      const neuronId = BigInt(10);
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Error: error }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const call = () => governance.startDissolving(neuronId);
+      expect(call).rejects.toThrow(new GovernanceError(error));
+    });
+  });
+
+  describe("GovernanceCanister.stopDissolving", () => {
+    it("successfully stops dissolving process", async () => {
+      const neuronId = BigInt(10);
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Configure: {} }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const response = await governance.stopDissolving(neuronId);
+      expect(service.manage_neuron).toBeCalled();
+    });
+
+    it("throws error if response is error", async () => {
+      const error: GovernanceErrorDetail = {
+        error_message: "Some error",
+        error_type: 1,
+      };
+      const neuronId = BigInt(10);
+      const serviceResponse: ManageNeuronResponse = {
+        command: [{ Error: error }],
+      };
+      const service = mock<GovernanceService>();
+      service.manage_neuron.mockResolvedValue(serviceResponse);
+
+      const governance = GovernanceCanister.create({
+        certifiedServiceOverride: service,
+      });
+      const call = () => governance.stopDissolving(neuronId);
+      expect(call).rejects.toThrow(new GovernanceError(error));
+    });
+  });
 });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -17,6 +17,8 @@ import {
   toJoinCommunityFundRequest,
   toManageNeuronsFollowRequest,
   toRegisterVoteRequest,
+  toStartDissolvingRequest,
+  toStopDissolvingRequest,
 } from "./canisters/governance/request.converters";
 import {
   toArrayOfNeuronInfo,
@@ -222,6 +224,34 @@ export class GovernanceCanister {
       neuronId,
       additionalDissolveDelaySeconds,
     });
+
+    return manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+  };
+
+  /**
+   * Start dissolving process of a neuron
+   *
+   * @throws {@link GovernanceError}
+   */
+  public startDissolving = async (neuronId: NeuronId): Promise<void> => {
+    const request = toStartDissolvingRequest(neuronId);
+
+    return manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+  };
+
+  /**
+   * Stop dissolving process of a neuron
+   *
+   * @throws {@link GovernanceError}
+   */
+  public stopDissolving = async (neuronId: NeuronId): Promise<void> => {
+    const request = toStopDissolvingRequest(neuronId);
 
     return manageNeuron({
       request,


### PR DESCRIPTION
# Motivation

Governance canister methods to start and stop the dissolving process.

# Changes

* New method `startDissolving`.
* New method `stopDissolving`.

# Tests

* Test for startDissolving and startDissolving.
