### PR TITLE
feat: ledger transfer default fee and memo

### DIFF
--- a/src/canisters/ledger/ledger.request.converts.ts
+++ b/src/canisters/ledger/ledger.request.converts.ts
@@ -1,0 +1,16 @@
+import { ICPTs, Subaccount } from "../../../proto/ledger_pb";
+import { SUB_ACCOUNT_BYTE_LENGTH } from "../../constants/constants";
+import { numberToArrayBuffer } from "../../utils/converter.utils";
+
+export const subAccountIdToSubaccount = (subAccountId: number): Subaccount => {
+  const bytes = numberToArrayBuffer(subAccountId, SUB_ACCOUNT_BYTE_LENGTH);
+  const subaccount: Subaccount = new Subaccount();
+  subaccount.setSubAccount(new Uint8Array(bytes));
+  return subaccount;
+};
+
+export const toICPTs = (amount: bigint): ICPTs => {
+  const result = new ICPTs();
+  result.setE8s(amount.toString(10));
+  return result;
+};

--- a/src/ledger.spec.ts
+++ b/src/ledger.spec.ts
@@ -1,4 +1,7 @@
+import { Memo, Payment, SendRequest } from "../proto/ledger_pb";
 import { AccountIdentifier } from "./account_identifier";
+import { toICPTs } from "./canisters/ledger/ledger.request.converts";
+import { TRANSACTION_FEE } from "./constants/constants";
 import {
   InsufficientFundsError,
   InvalidSenderError,
@@ -8,24 +11,26 @@ import {
 } from "./errors/ledger.errors";
 import { ICP } from "./icp";
 import { LedgerCanister } from "./ledger";
+import {E8s} from './types/common';
 
 describe("LedgerCanister.transfer", () => {
+  const to = AccountIdentifier.fromHex(
+    "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
+  );
+  const amount = ICP.fromE8s(BigInt(100000));
+
   it("handles invalid sender", async () => {
     const ledger = LedgerCanister.create({
       updateCallOverride: () => {
-        return Promise.resolve(
-          Error(`Reject code: 5
-            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'Sending from 2vxsx-fae is not allowed', rosetta-api/ledger_canister/src/main.rs:135:9`)
-        );
+        throw new Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'Sending from 2vxsx-fae is not allowed', rosetta-api/ledger_canister/src/main.rs:135:9`);
       },
     });
 
     const call = async () =>
       await ledger.transfer({
-        to: AccountIdentifier.fromHex(
-          "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
-        ),
-        amount: ICP.fromE8s(BigInt(100000)),
+        to,
+        amount,
       });
 
     await expect(call).rejects.toThrow(new InvalidSenderError());
@@ -34,19 +39,15 @@ describe("LedgerCanister.transfer", () => {
   it("handles duplicate transaction", async () => {
     const ledger = LedgerCanister.create({
       updateCallOverride: () => {
-        return Promise.resolve(
-          Error(`Reject code: 5
-            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is a duplicate of another transaction in block 1235123', rosetta-api/ledger_canister/src/main.rs:135:9`)
-        );
+        throw new Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is a duplicate of another transaction in block 1235123', rosetta-api/ledger_canister/src/main.rs:135:9`);
       },
     });
 
     const call = async () =>
       await ledger.transfer({
-        to: AccountIdentifier.fromHex(
-          "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
-        ),
-        amount: ICP.fromE8s(BigInt(100000)),
+        to,
+        amount,
       });
 
     await expect(call).rejects.toThrow(new TxDuplicateError(BigInt(1235123)));
@@ -55,19 +56,15 @@ describe("LedgerCanister.transfer", () => {
   it("handles insufficient balance", async () => {
     const ledger = LedgerCanister.create({
       updateCallOverride: () => {
-        return Promise.resolve(
-          Error(`Reject code: 5
-            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'the debit account doesn't have enough funds to complete the transaction, current balance: 123.46789123', rosetta-api/ledger_canister/src/main.rs:135:9`)
-        );
+        throw new Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'the debit account doesn't have enough funds to complete the transaction, current balance: 123.46789123', rosetta-api/ledger_canister/src/main.rs:135:9`);
       },
     });
 
     const call = async () =>
       await ledger.transfer({
-        to: AccountIdentifier.fromHex(
-          "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
-        ),
-        amount: ICP.fromE8s(BigInt(100000)),
+        to,
+        amount,
       });
 
     await expect(call).rejects.toThrow(
@@ -78,19 +75,15 @@ describe("LedgerCanister.transfer", () => {
   it("handles future tx", async () => {
     const ledger = LedgerCanister.create({
       updateCallOverride: () => {
-        return Promise.resolve(
-          Error(`Reject code: 5
-            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction's created_at_time is in future', rosetta-api/ledger_canister/src/main.rs:135:9`)
-        );
+        throw new Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction's created_at_time is in future', rosetta-api/ledger_canister/src/main.rs:135:9`);
       },
     });
 
     const call = async () =>
       await ledger.transfer({
-        to: AccountIdentifier.fromHex(
-          "a2a794c66495083317e4be5197eb655b1e63015469d769e2338af3d3e3f3aa86"
-        ),
-        amount: ICP.fromE8s(BigInt(100000)),
+        to,
+        amount,
       });
 
     await expect(call).rejects.toThrow(new TxCreatedInFutureError());
@@ -99,19 +92,15 @@ describe("LedgerCanister.transfer", () => {
   it("handles old tx", async () => {
     const ledger = LedgerCanister.create({
       updateCallOverride: () => {
-        return Promise.resolve(
-          Error(`Reject code: 5
-            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is older than 123 seconds', rosetta-api/ledger_canister/src/main.rs:135:9`)
-        );
+        throw new Error(`Reject code: 5
+            Reject text: Canister ryjl3-tyaaa-aaaaa-aaaba-cai trapped explicitly: Panicked at 'transaction is older than 123 seconds', rosetta-api/ledger_canister/src/main.rs:135:9`);
       },
     });
 
     const call = async () =>
       await ledger.transfer({
-        to: AccountIdentifier.fromHex(
-          "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
-        ),
-        amount: ICP.fromE8s(BigInt(100000)),
+        to,
+        amount,
       });
 
     await expect(call).rejects.toThrow(new TxTooOldError(123));
@@ -125,13 +114,119 @@ describe("LedgerCanister.transfer", () => {
     });
 
     const res = await ledger.transfer({
-      to: AccountIdentifier.fromHex(
-        "3e8bbceef8b9338e56a1b561a127326e6614894ab9b0739df4cc3664d40a5958"
-      ),
-      amount: ICP.fromE8s(BigInt(100000)),
+      to,
+      amount,
       fromSubAccountId: 1234,
     });
 
     expect(typeof res).toEqual("bigint");
+  });
+
+  const initExceptedRequest = ({
+    to,
+    amount,
+    memo,
+      fee
+  }: {
+    to: AccountIdentifier;
+    amount: ICP;
+    memo?: bigint;
+    fee?: E8s;
+  }): SendRequest => {
+    const expectedRequest = new SendRequest();
+    expectedRequest.setTo(to.toProto());
+
+    const payment = new Payment();
+    payment.setReceiverGets(amount.toProto());
+    expectedRequest.setPayment(payment);
+
+    const requestMemo: Memo = new Memo();
+    requestMemo.setMemo((memo ?? BigInt(0)).toString());
+    expectedRequest.setMemo(requestMemo);
+
+    expectedRequest.setMaxFee(toICPTs(fee ?? TRANSACTION_FEE));
+
+    return expectedRequest;
+  };
+
+  it("should set a default fee for a transfer", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => Promise.resolve(new Uint8Array()),
+    });
+
+    // @ts-ignore - private function
+    const spy = jest.spyOn(ledger, "updateFetcher");
+
+    const expectedRequest = initExceptedRequest({ to, amount });
+
+    await ledger.transfer({
+      to,
+      amount,
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      // @ts-ignore - private variable
+      agent: ledger.agent,
+      // @ts-ignore - private variable
+      canisterId: ledger.canisterId,
+      methodName: "send_pb",
+      arg: expectedRequest.serializeBinary(),
+    });
+  });
+
+  it("should use custom fee for a transfer", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => Promise.resolve(new Uint8Array()),
+    });
+
+    // @ts-ignore - private function
+    const spy = jest.spyOn(ledger, "updateFetcher");
+
+    const fee = BigInt(990_000);
+
+    const expectedRequest = initExceptedRequest({ to, amount, fee });
+
+    await ledger.transfer({
+      to,
+      amount,
+      fee,
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      // @ts-ignore - private variable
+      agent: ledger.agent,
+      // @ts-ignore - private variable
+      canisterId: ledger.canisterId,
+      methodName: "send_pb",
+      arg: expectedRequest.serializeBinary(),
+    });
+  });
+
+  it("should use custom memo for a transfer", async () => {
+    const ledger = LedgerCanister.create({
+      updateCallOverride: () => Promise.resolve(new Uint8Array()),
+    });
+
+    // @ts-ignore - private function
+    const spy = jest.spyOn(ledger, "updateFetcher");
+
+    const memo = BigInt(990_000);
+
+    const expectedRequest = initExceptedRequest({ to, amount, memo });
+
+    await ledger.transfer({
+      to,
+      amount,
+      memo,
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      // @ts-ignore - private variable
+      agent: ledger.agent,
+      // @ts-ignore - private variable
+      canisterId: ledger.canisterId,
+      methodName: "send_pb",
+      arg: expectedRequest.serializeBinary(),
+    });
   });
 });

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,6 +1,3 @@
-import { Agent } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
-
 export type CanisterIdString = string;
 export type NeuronId = bigint;
 export type AccountIdentifier = string;
@@ -9,12 +6,5 @@ export type E8s = bigint;
 export type Memo = bigint;
 export type PrincipalString = string;
 export type SubAccount = Uint8Array;
-
-export type CanisterCall = (
-  agent: Agent,
-  canisterId: Principal,
-  methodName: string,
-  arg: ArrayBuffer
-) => Promise<Uint8Array | Error>;
 
 export type Option<T> = T | undefined;

--- a/src/types/ledger.ts
+++ b/src/types/ledger.ts
@@ -1,6 +1,12 @@
 import { Agent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
-import { CanisterCall } from "./common";
+
+export type LedgerCanisterCall = (params: {
+  agent: Agent;
+  canisterId: Principal;
+  methodName: string;
+  arg: ArrayBuffer;
+}) => Promise<Uint8Array>;
 
 // HttpAgent options that can be used at construction.
 export interface LedgerCanisterOptions {
@@ -10,8 +16,8 @@ export interface LedgerCanisterOptions {
   canisterId?: Principal;
   // The method to use for performing an update call. Primarily overridden
   // in test for mocking.
-  updateCallOverride?: CanisterCall;
+  updateCallOverride?: LedgerCanisterCall;
   // The method to use for performing a query call. Primarily overridden
   // in test for mocking.
-  queryCallOverride?: CanisterCall;
+  queryCallOverride?: LedgerCanisterCall;
 }

--- a/src/utils/proto.utils.ts
+++ b/src/utils/proto.utils.ts
@@ -5,12 +5,17 @@ import { Principal } from "@dfinity/principal";
  * Submits an update call to the IC.
  * @returns The (binary) response if the request succeeded, an error otherwise.
  */
-export const updateCall = async (
-  agent: Agent,
-  canisterId: Principal,
-  methodName: string,
-  arg: ArrayBuffer
-): Promise<Uint8Array | Error> => {
+export const updateCall = async ({
+  agent,
+  canisterId,
+  methodName,
+  arg,
+}: {
+  agent: Agent;
+  canisterId: Principal;
+  methodName: string;
+  arg: ArrayBuffer;
+}): Promise<Uint8Array> => {
   const submitResponse = await agent.call(canisterId, {
     methodName,
     arg,
@@ -18,7 +23,7 @@ export const updateCall = async (
   });
 
   if (!submitResponse.response.ok) {
-    return Error(
+    throw new Error(
       [
         "Call failed:",
         `  Method: ${methodName}`,
@@ -30,42 +35,38 @@ export const updateCall = async (
     );
   }
 
-  try {
-    const blob = await polling.pollForResponse(
-      agent,
-      canisterId,
-      submitResponse.requestId,
-      polling.defaultStrategy()
-    );
-    return new Uint8Array(blob);
-  } catch (err) {
-    if (err instanceof Error) {
-      // Return errors rather than throw them so that callers are forced to handle them.
-      return err;
-    }
+  const blob = await polling.pollForResponse(
+    agent,
+    canisterId,
+    submitResponse.requestId,
+    polling.defaultStrategy()
+  );
 
-    // Something very wrong happened, and we don't know how to deal with it. Throw as-is.
-    throw err;
-  }
+  return new Uint8Array(blob);
 };
 
 /**
  * Submits a query call to the IC.
  * @returns The (binary) response if the request succeeded, an error otherwise.
  */
-export const queryCall = async (
-  agent: Agent,
-  canisterId: Principal,
-  methodName: string,
-  arg: ArrayBuffer
-): Promise<Uint8Array | Error> => {
+export const queryCall = async ({
+  agent,
+  canisterId,
+  methodName,
+  arg,
+}: {
+  agent: Agent;
+  canisterId: Principal;
+  methodName: string;
+  arg: ArrayBuffer;
+}): Promise<Uint8Array> => {
   const queryResponse = await agent.query(canisterId, {
     methodName,
     arg,
   });
 
   if (queryResponse.status == "rejected") {
-    return new Error(
+    throw new Error(
       [
         "Call failed:",
         `  Method: ${methodName}`,


### PR DESCRIPTION
# Motivation

For compatibility with ledger wallet - hardware wallet - we should pass a default `memo` to process a transfer with the ledger. We can also set a default transaction fee.

These two operations were previously performed in the Flutter - ts bridge context.

# Changes

- add options `memo` and `fee` to ledger `transfer` function
- set default memo to `BigInt(0)`
- set default fee to `BigInt(10_000)`
- refactor canister calls params and throw errors
