### PR TITLE
feat: add votableNeurons util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0 (TBD)
+
+### Breaking Changes
+
+- replace `notVotedNeurons` with `votableNeurons` [#77]
+
 # 0.3.0 (2022-04-07)
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/agent": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",

--- a/src/utils/neurons.utils.spec.ts
+++ b/src/utils/neurons.utils.spec.ts
@@ -2,6 +2,7 @@ import { NeuronInfo, ProposalInfo, Vote } from "../types/governance_converters";
 import {
   ineligibleNeurons,
   notVotedNeurons,
+  votableNeurons,
   votedNeurons,
 } from "./neurons.utils";
 
@@ -179,4 +180,30 @@ describe("neurons-utils", () => {
     });
     expect(voted.length).toEqual(1);
   });
+
+  it("should have votable neurons only with voting power", () => {
+    const votable = votableNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(0),
+        },
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(1),
+        },
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(0),
+        },
+      ],
+    });
+    expect(votable.length).toEqual(1);
+    expect(votable[0].votingPower).toEqual(BigInt(1));
+  });
+
 });

--- a/src/utils/neurons.utils.spec.ts
+++ b/src/utils/neurons.utils.spec.ts
@@ -1,7 +1,6 @@
 import { NeuronInfo, ProposalInfo, Vote } from "../types/governance_converters";
 import {
   ineligibleNeurons,
-  notVotedNeurons,
   votableNeurons,
   votedNeurons,
 } from "./neurons.utils";
@@ -45,6 +44,7 @@ describe("neurons-utils", () => {
       createdTimestampSeconds: proposalTimestampSeconds - BigInt(1),
       neuronId: proposalNeuronId,
       recentBallots: [],
+      votingPower: BigInt(1),
     } as unknown as NeuronInfo,
   ];
 
@@ -69,22 +69,22 @@ describe("neurons-utils", () => {
     expect(ineligible.length).toEqual(0);
   });
 
-  it("should not have not voted neurons because ineligible", () => {
-    let notVoted = notVotedNeurons({
+  it("should not have votable neurons because ineligible", () => {
+    let notVoted = votableNeurons({
       proposal,
       neurons: ineligibleNeuronsDate,
     });
     expect(notVoted.length).toEqual(0);
 
-    notVoted = notVotedNeurons({
+    notVoted = votableNeurons({
       proposal,
       neurons: ineligibleNeuronsTooShort,
     });
     expect(notVoted.length).toEqual(0);
   });
 
-  it("should not have not voted neurons because already voted", () => {
-    const notVoted = notVotedNeurons({
+  it("should not have votable neurons because already voted", () => {
+    const notVoted = votableNeurons({
       proposal,
       neurons: [
         {
@@ -101,8 +101,8 @@ describe("neurons-utils", () => {
     expect(notVoted.length).toEqual(0);
   });
 
-  it("should have not voted neurons because not yet voted", () => {
-    const notVoted = notVotedNeurons({
+  it("should have votable neurons because not yet voted", () => {
+    const notVoted = votableNeurons({
       proposal,
       neurons: [
         {
@@ -119,8 +119,8 @@ describe("neurons-utils", () => {
     expect(notVoted.length).toEqual(1);
   });
 
-  it("should have not voted neurons because never voted", () => {
-    const notVoted = notVotedNeurons({
+  it("should have votable neurons because never voted", () => {
+    const notVoted = votableNeurons({
       proposal,
       neurons: [
         {
@@ -132,7 +132,32 @@ describe("neurons-utils", () => {
     expect(notVoted.length).toEqual(1);
   });
 
-  it("should not have voted neurons because not voted", () => {
+  it("should have votable neurons only with voting power", () => {
+    const votable = votableNeurons({
+      proposal,
+      neurons: [
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(0),
+        },
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(1),
+        },
+        {
+          ...eligibleNeuronsDate[0],
+          recentBallots: [],
+          votingPower: BigInt(0),
+        },
+      ],
+    });
+    expect(votable.length).toEqual(1);
+    expect(votable[0].votingPower).toEqual(BigInt(1));
+  });
+
+  it("should not have voted neurons because votable", () => {
     const voted = votedNeurons({
       proposal,
       neurons: [
@@ -179,31 +204,6 @@ describe("neurons-utils", () => {
       ],
     });
     expect(voted.length).toEqual(1);
-  });
-
-  it("should have votable neurons only with voting power", () => {
-    const votable = votableNeurons({
-      proposal,
-      neurons: [
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [],
-          votingPower: BigInt(0),
-        },
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [],
-          votingPower: BigInt(1),
-        },
-        {
-          ...eligibleNeuronsDate[0],
-          recentBallots: [],
-          votingPower: BigInt(0),
-        },
-      ],
-    });
-    expect(votable.length).toEqual(1);
-    expect(votable[0].votingPower).toEqual(BigInt(1));
   });
 
 });

--- a/src/utils/neurons.utils.spec.ts
+++ b/src/utils/neurons.utils.spec.ts
@@ -70,21 +70,21 @@ describe("neurons-utils", () => {
   });
 
   it("should not have votable neurons because ineligible", () => {
-    let notVoted = votableNeurons({
+    let votable = votableNeurons({
       proposal,
       neurons: ineligibleNeuronsDate,
     });
-    expect(notVoted.length).toEqual(0);
+    expect(votable.length).toEqual(0);
 
-    notVoted = votableNeurons({
+    votable = votableNeurons({
       proposal,
       neurons: ineligibleNeuronsTooShort,
     });
-    expect(notVoted.length).toEqual(0);
+    expect(votable.length).toEqual(0);
   });
 
   it("should not have votable neurons because already voted", () => {
-    const notVoted = votableNeurons({
+    const votable = votableNeurons({
       proposal,
       neurons: [
         {
@@ -98,11 +98,11 @@ describe("neurons-utils", () => {
         },
       ],
     });
-    expect(notVoted.length).toEqual(0);
+    expect(votable.length).toEqual(0);
   });
 
   it("should have votable neurons because not yet voted", () => {
-    const notVoted = votableNeurons({
+    const votable = votableNeurons({
       proposal,
       neurons: [
         {
@@ -116,11 +116,11 @@ describe("neurons-utils", () => {
         },
       ],
     });
-    expect(notVoted.length).toEqual(1);
+    expect(votable.length).toEqual(1);
   });
 
   it("should have votable neurons because never voted", () => {
-    const notVoted = votableNeurons({
+    const votable = votableNeurons({
       proposal,
       neurons: [
         {
@@ -129,7 +129,7 @@ describe("neurons-utils", () => {
         },
       ],
     });
-    expect(notVoted.length).toEqual(1);
+    expect(votable.length).toEqual(1);
   });
 
   it("should have votable neurons only with voting power", () => {

--- a/src/utils/neurons.utils.ts
+++ b/src/utils/neurons.utils.ts
@@ -65,6 +65,14 @@ export const notVotedNeurons = ({
   );
 };
 
+/**
+ * Return not voted neurons that have voting power
+ */
+export const votableNeurons = (params: {
+  neurons: NeuronInfo[];
+  proposal: ProposalInfo;
+}): NeuronInfo[] => notVotedNeurons(params).filter(({ votingPower }) => votingPower > 0n);
+
 export const votedNeurons = ({
   neurons,
   proposal,

--- a/src/utils/neurons.utils.ts
+++ b/src/utils/neurons.utils.ts
@@ -46,7 +46,10 @@ export const ineligibleNeurons = ({
   });
 };
 
-export const notVotedNeurons = ({
+/**
+ * Neurons that can vote for the proposal (not voted, with voting power)
+ */
+export const votableNeurons = ({
   neurons,
   proposal,
 }: {
@@ -62,16 +65,8 @@ export const notVotedNeurons = ({
         ({ neuronId: ineligibleNeuronId }: NeuronInfo) =>
           ineligibleNeuronId === neuronId
       ) === undefined
-  );
+  ).filter(({ votingPower }) => votingPower > 0n)
 };
-
-/**
- * Return not voted neurons that have voting power
- */
-export const votableNeurons = (params: {
-  neurons: NeuronInfo[];
-  proposal: ProposalInfo;
-}): NeuronInfo[] => notVotedNeurons(params).filter(({ votingPower }) => votingPower > 0n);
 
 export const votedNeurons = ({
   neurons,


### PR DESCRIPTION
# Motivation

To improve the logic and avoid the bug (selction of neuron-with-0-voting-power) 'votableNeurons' was added.
Later we could refactor the nns-dapp to switch from custom code to this function.

@peterpeterparker Do we need `notVotedNeurons`? Currently it is used only in the code that will be replaced with `votableNeurons`.

# Changes

- votableNeurons util

# Tests

- votableNeurons test