### PR TITLE
Revert "Disable shfmt due to installation problems (#81)"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      #- name: Install shfmt
-      #  run: sudo snap install --classic shfmt
+      - name: Install shfmt
+        run: sudo snap install --classic shfmt
 
-      #- name: Format shell scripts
-      #  run: ./scripts/fmt-sh
+      - name: Format shell scripts
+        run: ./scripts/fmt-sh
 
       - name: Install ts dependencies
         run: npm ci


### PR DESCRIPTION
This reverts commit 6c1487f5b90bff657baeff1fe41ae6739917e0d6.

# Motivation

shfmt was failing to install with what looks like a network problem in AWS.  The above PR disabled shfmt.  As soon as shfmt is available again, CI should be green for this PR and it can be merged.

# Changes
- Re-enable shell script formatting.