### PR TITLE
L2-314: Change Deprecated Method to claim neuron

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -535,11 +535,18 @@ export const toClaimOrRefreshRequest = ({
   controller,
 }: {
   memo: bigint;
-  controller: Principal;
+  controller?: Principal;
 }): RawManageNeuron => {
   const rawCommand: RawCommand = {
     ClaimOrRefresh: {
-      by: [{ MemoAndController: { controller: [controller], memo } }],
+      by: [
+        {
+          MemoAndController: {
+            controller: controller == undefined ? [] : [controller],
+            memo,
+          },
+        },
+      ],
     },
   };
 

--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -17,7 +17,12 @@ import {
   RewardMode as RawRewardMode,
 } from "../../../candid/governanceTypes.d";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import { AccountIdentifier, E8s, NeuronId } from "../../types/common";
+import {
+  AccountIdentifier,
+  E8s,
+  NeuronId,
+  SubAccount,
+} from "../../types/common";
 import {
   Action,
   By,
@@ -527,6 +532,28 @@ export const fromClaimOrRefreshNeuronRequest = (
     id: [],
     command: [rawCommand],
     neuron_id_or_subaccount: [{ NeuronId: { id: request.neuronId } }],
+  };
+};
+
+export const toClaimOrRefreshRequest = ({
+  memo,
+  controller,
+  subAccount,
+}: {
+  memo: bigint;
+  controller: Principal;
+  subAccount: SubAccount;
+}): RawManageNeuron => {
+  const rawCommand: RawCommand = {
+    ClaimOrRefresh: {
+      by: [{ MemoAndController: { controller: [controller], memo } }],
+    },
+  };
+
+  return {
+    id: [],
+    command: [rawCommand],
+    neuron_id_or_subaccount: [{ Subaccount: Array.from(subAccount) }],
   };
 };
 

--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -17,12 +17,7 @@ import {
   RewardMode as RawRewardMode,
 } from "../../../candid/governanceTypes.d";
 import { UnsupportedValueError } from "../../errors/governance.errors";
-import {
-  AccountIdentifier,
-  E8s,
-  NeuronId,
-  SubAccount,
-} from "../../types/common";
+import { AccountIdentifier, E8s, NeuronId } from "../../types/common";
 import {
   Action,
   By,
@@ -538,11 +533,9 @@ export const fromClaimOrRefreshNeuronRequest = (
 export const toClaimOrRefreshRequest = ({
   memo,
   controller,
-  subAccount,
 }: {
   memo: bigint;
   controller: Principal;
-  subAccount: SubAccount;
 }): RawManageNeuron => {
   const rawCommand: RawCommand = {
     ClaimOrRefresh: {
@@ -553,7 +546,7 @@ export const toClaimOrRefreshRequest = ({
   return {
     id: [],
     command: [rawCommand],
-    neuron_id_or_subaccount: [{ Subaccount: Array.from(subAccount) }],
+    neuron_id_or_subaccount: [],
   };
 };
 

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -9,7 +9,6 @@ import {
   ManageNeuronResponse,
   ProposalInfo as RawProposalInfo,
 } from "../candid/governanceTypes";
-import { SubAccount } from "./account_identifier";
 import {
   GovernanceError,
   InsufficientAmountError,
@@ -350,7 +349,6 @@ describe("GovernanceCanister.claimOrRefreshNeuronFromAccount", () => {
     const response = await governance.claimOrRefreshNeuronFromAccount({
       memo: BigInt(1),
       controller: principal,
-      subAccount: SubAccount.fromPrincipal(principal),
     });
     expect(service.manage_neuron).toBeCalled();
     expect(response).toBe(neuronId);
@@ -371,7 +369,6 @@ describe("GovernanceCanister.claimOrRefreshNeuronFromAccount", () => {
       governance.claimOrRefreshNeuronFromAccount({
         memo: BigInt(1),
         controller: principal,
-        subAccount: SubAccount.fromPrincipal(principal),
       });
     expect(call).rejects.toThrow(UnrecognizedTypeError);
   });

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -199,7 +199,6 @@ export class GovernanceCanister {
       await this.claimOrRefreshNeuronFromAccount({
         controller: principal,
         memo: nonce,
-        subAccount: toSubAccount,
       });
 
     // Typescript was complaining with `neuronId || new NeuronNotFound()`:
@@ -422,16 +421,13 @@ export class GovernanceCanister {
   public claimOrRefreshNeuronFromAccount = async ({
     memo,
     controller,
-    subAccount,
   }: {
     memo: bigint;
     controller: Principal;
-    subAccount: SubAccount;
   }): Promise<NeuronId | undefined> => {
     const rawRequest = toClaimOrRefreshRequest({
       memo,
       controller,
-      subAccount: subAccount.toUint8Array(),
     });
     const rawResponse = await this.certifiedService.manage_neuron(rawRequest);
     const { command } = rawResponse;

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -423,7 +423,7 @@ export class GovernanceCanister {
     controller,
   }: {
     memo: bigint;
-    controller: Principal;
+    controller?: Principal;
   }): Promise<NeuronId | undefined> => {
     const rawRequest = toClaimOrRefreshRequest({
       memo,

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -13,6 +13,7 @@ import {
   fromClaimOrRefreshNeuronRequest,
   fromListNeurons,
   fromListProposalsRequest,
+  toClaimOrRefreshRequest,
   toIncreaseDissolveDelayRequest,
   toJoinCommunityFundRequest,
   toMakeProposalRawRequest,
@@ -42,7 +43,6 @@ import { LedgerCanister } from "./ledger";
 import { NeuronId } from "./types/common";
 import { GovernanceCanisterOptions } from "./types/governance";
 import {
-  ClaimOrRefreshNeuronFromAccount,
   ClaimOrRefreshNeuronRequest,
   FollowRequest,
   KnownNeuron,
@@ -199,6 +199,7 @@ export class GovernanceCanister {
       await this.claimOrRefreshNeuronFromAccount({
         controller: principal,
         memo: nonce,
+        subAccount: toSubAccount,
       });
 
     // Typescript was complaining with `neuronId || new NeuronNotFound()`:
@@ -418,23 +419,30 @@ export class GovernanceCanister {
   /**
    * Gets the NeuronID of a newly created neuron.
    */
-  public claimOrRefreshNeuronFromAccount = async (
-    request: ClaimOrRefreshNeuronFromAccount
-  ): Promise<NeuronId | undefined> => {
-    // Note: This is an update call so the certified and uncertified services are identical in this case,
-    // however using the certified service provides protection in case that changes.
-    const response =
-      await this.certifiedService.claim_or_refresh_neuron_from_account({
-        controller: request.controller ? [request.controller] : [],
-        memo: request.memo,
-      });
-
-    const { result } = response;
-    if (result.length && "NeuronId" in result[0]) {
-      return result[0].NeuronId.id;
+  public claimOrRefreshNeuronFromAccount = async ({
+    memo,
+    controller,
+    subAccount,
+  }: {
+    memo: bigint;
+    controller: Principal;
+    subAccount: SubAccount;
+  }): Promise<NeuronId | undefined> => {
+    const rawRequest = toClaimOrRefreshRequest({
+      memo,
+      controller,
+      subAccount: subAccount.toUint8Array(),
+    });
+    const rawResponse = await this.certifiedService.manage_neuron(rawRequest);
+    const { command } = rawResponse;
+    if (command.length && "ClaimOrRefresh" in command[0]) {
+      const claim = command[0].ClaimOrRefresh;
+      return claim.refreshed_neuron_id[0]?.id;
     }
 
-    return undefined;
+    throw new UnrecognizedTypeError(
+      `Unrecognized ClaimOrRefresh error in ${JSON.stringify(rawResponse)}`
+    );
   };
 
   /**


### PR DESCRIPTION
# Motivation

ClaimOrRefreshNeuronFromSubaccount uses manage neuron method.

`claim_or_refresh_neuron_from_account` is deprecated: https://github.com/dfinity/ic/blob/master/rs/nns/governance/canister/canister.rs#L393

# Changes

* claimOrRefreshNeuronFromAccount uses `mange_neuron` governance canister method

# Tests

* Change tests to stake a neuron to mock changed call.
* New tests for claimOrRefreshNeuronFromAccount method.
