### PR TITLE
feat: expose account identifier utils

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -37,10 +37,8 @@ import {
   RewardMode,
   Vote,
 } from "../../types/governance_converters";
-import {
-  accountIdentifierToBytes,
-  arrayBufferToArrayOfNumber,
-} from "../../utils/converter.utils";
+import { accountIdentifierToBytes } from "../../utils/account_identifier.utils";
+import { arrayBufferToArrayOfNumber } from "../../utils/converter.utils";
 
 const fromProposalId = (proposalId: ProposalId): RawNeuronId => ({
   id: proposalId,

--- a/src/canisters/governance/response.converters.ts
+++ b/src/canisters/governance/response.converters.ts
@@ -49,9 +49,11 @@ import {
 } from "../../types/governance_converters";
 import {
   accountIdentifierFromBytes,
+  principalToAccountIdentifier,
+} from "../../utils/account_identifier.utils";
+import {
   arrayOfNumberToArrayBuffer,
   arrayOfNumberToUint8Array,
-  principalToAccountIdentifier,
 } from "../../utils/converter.utils";
 // Protobuf is not supported yet:
 // import { ManageNeuronResponse as PbManageNeuronResponse } from "../../proto/governance_pb";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export * from "./types/governance";
 export * from "./types/governance_converters";
 export * from "./types/icp";
 export * from "./types/ledger";
+export * from "./utils/account_identifier.utils";
 export * from "./utils/neurons.utils";

--- a/src/utils/account_identifier.utils.ts
+++ b/src/utils/account_identifier.utils.ts
@@ -1,0 +1,39 @@
+import { Principal } from "@dfinity/principal";
+import { Buffer } from "buffer";
+import { sha224 } from "js-sha256";
+import { AccountIdentifier } from "../types/common";
+import {
+  asciiStringToByteArray,
+  calculateCrc32,
+  toHexString,
+} from "./converter.utils";
+
+export const accountIdentifierToBytes = (
+  accountIdentifier: AccountIdentifier
+): Uint8Array =>
+  Uint8Array.from(Buffer.from(accountIdentifier, "hex")).subarray(4);
+
+export const accountIdentifierFromBytes = (
+  accountIdentifier: Uint8Array
+): AccountIdentifier => Buffer.from(accountIdentifier).toString("hex");
+
+export const principalToAccountIdentifier = (
+  principal: Principal,
+  subAccount?: Uint8Array
+): string => {
+  // Hash (sha224) the principal, the subAccount and some padding
+  const padding = asciiStringToByteArray("\x0Aaccount-id");
+
+  const shaObj = sha224.create();
+  shaObj.update([
+    ...padding,
+    ...principal.toUint8Array(),
+    ...(subAccount ?? Array(32).fill(0)),
+  ]);
+  const hash = new Uint8Array(shaObj.array());
+
+  // Prepend the checksum of the hash and convert to a hex string
+  const checksum = calculateCrc32(hash);
+  const bytes = new Uint8Array([...checksum, ...hash]);
+  return toHexString(bytes);
+};

--- a/src/utils/converter.utils.ts
+++ b/src/utils/converter.utils.ts
@@ -1,10 +1,7 @@
-import { Principal } from "@dfinity/principal";
 import { Buffer } from "buffer";
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore (no type definitions for crc are available)
 import crc from "crc";
-import { sha224 } from "js-sha256";
-import { AccountIdentifier } from "../types/common";
 
 export const uint8ArrayToBigInt = (array: Uint8Array): bigint => {
   const view = new DataView(array.buffer, array.byteOffset, array.byteLength);
@@ -48,39 +45,6 @@ export const numberToArrayBuffer = (
 
 export const asciiStringToByteArray = (text: string): Array<number> => {
   return Array.from(text).map((c) => c.charCodeAt(0));
-};
-
-export const accountIdentifierToBytes = (
-  accountIdentifier: AccountIdentifier
-): Uint8Array => {
-  return Uint8Array.from(Buffer.from(accountIdentifier, "hex")).subarray(4);
-};
-
-export const accountIdentifierFromBytes = (
-  accountIdentifier: Uint8Array
-): AccountIdentifier => {
-  return Buffer.from(accountIdentifier).toString("hex");
-};
-
-export const principalToAccountIdentifier = (
-  principal: Principal,
-  subAccount?: Uint8Array
-): string => {
-  // Hash (sha224) the principal, the subAccount and some padding
-  const padding = asciiStringToByteArray("\x0Aaccount-id");
-
-  const shaObj = sha224.create();
-  shaObj.update([
-    ...padding,
-    ...principal.toUint8Array(),
-    ...(subAccount ?? Array(32).fill(0)),
-  ]);
-  const hash = new Uint8Array(shaObj.array());
-
-  // Prepend the checksum of the hash and convert to a hex string
-  const checksum = calculateCrc32(hash);
-  const bytes = new Uint8Array([...checksum, ...hash]);
-  return toHexString(bytes);
 };
 
 export const toHexString = (bytes: Uint8Array) =>


### PR DESCRIPTION
# Motivation

To display the account identifier of the ledger identity in nns-dapp we need to access the existing converter `principalToAccountIdentifier`.

# Changes

- expose account identifier utils
- move account identifier utils to dedicated file from generic converter
