### PR TITLE
L2-373: Spawn Neuron

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -889,6 +889,28 @@ export const toMergeMaturityRequest = ({
     },
   });
 
+export const toSpawnNeuronRequest = ({
+  neuronId,
+  percentageToSpawn,
+  newController,
+  nonce,
+}: {
+  neuronId: NeuronId;
+  percentageToSpawn: number;
+  newController?: Principal;
+  nonce?: bigint;
+}): RawManageNeuron =>
+  toCommand({
+    neuronId,
+    command: {
+      Spawn: {
+        percentage_to_spawn: [percentageToSpawn],
+        new_controller: newController === undefined ? [] : [newController],
+        nonce: nonce === undefined ? [] : [nonce],
+      },
+    },
+  });
+
 export const toAddHotkeyRequest = ({
   neuronId,
   principal,

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -24,6 +24,7 @@ import {
   toMergeRequest,
   toRegisterVoteRequest,
   toRemoveHotkeyRequest,
+  toSpawnNeuronRequest,
   toSplitRawRequest,
   toStartDissolvingRequest,
   toStopDissolvingRequest,
@@ -466,6 +467,40 @@ export class GovernanceCanister {
     assertPercentageNumber(percentageToMerge);
 
     const request = toMergeMaturityRequest({ neuronId, percentageToMerge });
+
+    return manageNeuron({
+      request,
+      service: this.certifiedService,
+    });
+  };
+
+  /**
+   * Merge Maturity of a neuron
+   *
+   * @throws {@link GovernanceError}
+   * @throws {@link InvalidPercentageError}
+   *
+   */
+  public spawnNeuron = async ({
+    neuronId,
+    percentageToSpawn,
+    newController,
+    nonce,
+  }: {
+    neuronId: NeuronId;
+    percentageToSpawn: number;
+    newController?: Principal;
+    nonce?: bigint;
+  }): Promise<void> => {
+    // Migth throw InvalidPercentageError
+    assertPercentageNumber(percentageToSpawn);
+
+    const request = toSpawnNeuronRequest({
+      neuronId,
+      percentageToSpawn,
+      newController,
+      nonce,
+    });
 
     return manageNeuron({
       request,


### PR DESCRIPTION
# Motivation

Method to spawn a neuron from maturity.

# Changes

* New method in governance service "spawnNeuron".

# Tests

* Test for new method "spawnNeuron".
