### PR TITLE
build: downgrade typescript for eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ts-jest": "^28.0.2",
         "ts-protoc-gen": "^0.15.0",
         "typedoc": "^0.22.15",
-        "typescript": "^4.6.4",
+        "typescript": "^4.5.5",
         "whatwg-fetch": "^3.6.2"
       }
     },
@@ -6705,9 +6705,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11712,9 +11712,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ts-jest": "^28.0.2",
     "ts-protoc-gen": "^0.15.0",
     "typedoc": "^0.22.15",
-    "typescript": "^4.6.4",
+    "typescript": "^4.5.5",
     "whatwg-fetch": "^3.6.2"
   },
   "repository": {


### PR DESCRIPTION
# Motivation

eslint does not support yet typescript v4.6+

# Changes

- downgrade typescript to v4.5.5
