### PR TITLE
L2-514: Hide Spawn neuron percentage for HW

### DIFF
--- a/src/canisters/governance/request.converters.ts
+++ b/src/canisters/governance/request.converters.ts
@@ -896,7 +896,7 @@ export const toSpawnNeuronRequest = ({
   nonce,
 }: {
   neuronId: NeuronId;
-  percentageToSpawn: number;
+  percentageToSpawn?: number;
   newController?: Principal;
   nonce?: bigint;
 }): RawManageNeuron =>
@@ -904,7 +904,8 @@ export const toSpawnNeuronRequest = ({
     neuronId,
     command: {
       Spawn: {
-        percentage_to_spawn: [percentageToSpawn],
+        percentage_to_spawn:
+          percentageToSpawn === undefined ? [] : [percentageToSpawn],
         new_controller: newController === undefined ? [] : [newController],
         nonce: nonce === undefined ? [] : [nonce],
       },

--- a/src/canisters/governance/services.ts
+++ b/src/canisters/governance/services.ts
@@ -1,6 +1,33 @@
 import { GovernanceService } from "../../../candid/governance.idl";
-import { ManageNeuron } from "../../../candid/governanceTypes";
+import {
+  Command_1,
+  ManageNeuron,
+  ManageNeuronResponse,
+} from "../../../candid/governanceTypes";
 import { GovernanceError } from "../../errors/governance.errors";
+
+/**
+ * Checks a Manage Neuron Response for error and returns successful response data.
+ *
+ * @throws {@link GovernanceError}
+ */
+export const getSuccessfulCommandFromResponse = (
+  response: ManageNeuronResponse
+): Command_1 => {
+  const { command } = response;
+  const data = command[0];
+  if (!data) {
+    throw new GovernanceError({
+      error_message: "Error updating neuron",
+      error_type: 0,
+    });
+  }
+
+  if ("Error" in data) {
+    throw new GovernanceError(data.Error);
+  }
+  return response.command[0] as Command_1;
+};
 
 /**
  * @throws {@link GovernanceError}
@@ -12,17 +39,7 @@ export const manageNeuron = async ({
   request: ManageNeuron;
   service: GovernanceService;
 }): Promise<void> => {
-  const { command } = await service.manage_neuron(request);
-  const response = command[0];
-
-  if (!response) {
-    throw new GovernanceError({
-      error_message: "Error updating neuron",
-      error_type: 0,
-    });
-  }
-
-  if ("Error" in response) {
-    throw new GovernanceError(response.Error);
-  }
+  const response = await service.manage_neuron(request);
+  // We use it only to assert that there are no errors
+  getSuccessfulCommandFromResponse(response);
 };

--- a/src/canisters/governance/services.ts
+++ b/src/canisters/governance/services.ts
@@ -26,7 +26,7 @@ export const getSuccessfulCommandFromResponse = (
   if ("Error" in data) {
     throw new GovernanceError(data.Error);
   }
-  return response.command[0] as Command_1;
+  return data;
 };
 
 /**

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -844,11 +844,12 @@ describe("GovernanceCanister", () => {
 
   describe("GovernanceCanister.spawnNeuron", () => {
     it("successfully spawns new neuron", async () => {
+      const neuronId = BigInt(100_000);
       const serviceResponse: ManageNeuronResponse = {
         command: [
           {
             Spawn: {
-              created_neuron_id: [{ id: BigInt(100_000) }],
+              created_neuron_id: [{ id: neuronId }],
             },
           },
         ],
@@ -859,11 +860,12 @@ describe("GovernanceCanister", () => {
       const governance = GovernanceCanister.create({
         certifiedServiceOverride: service,
       });
-      await governance.spawnNeuron({
+      const response = await governance.spawnNeuron({
         neuronId: BigInt(10),
         percentageToSpawn: 50,
       });
       expect(service.manage_neuron).toBeCalled();
+      expect(response).toBe(neuronId);
     });
 
     it("throws error if percentage not valid", async () => {


### PR DESCRIPTION
# Motivation

Spawning a neuron does not need percentageToSpawn.

The ledger IC app does not yet support the property "percentageToSpawn" when spawning.

# Changes

* Make percentageToSpawn as optional.
* "spawnNeuron" returns new neuron id.
* Refactor some error management code.

# Tests

* Update test to check return value.
