### PR TITLE
feat: throw an error for unsupported list neurons query with hw

### DIFF
--- a/src/errors/governance.errors.ts
+++ b/src/errors/governance.errors.ts
@@ -29,3 +29,5 @@ export class UnsupportedValueError extends Error {
     super("Unsupported value: " + value);
   }
 }
+
+export class FeatureNotSupportedError extends Error {}

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -17,6 +17,7 @@ import {
 import { NeuronId as PbNeuronId } from "../proto/base_types_pb";
 import { ManageNeuronResponse as PbManageNeuronResponse } from "../proto/governance_pb";
 import {
+  FeatureNotSupportedError,
   GovernanceError,
   InsufficientAmountError,
   InvalidAccountIDError,
@@ -267,9 +268,24 @@ describe("GovernanceCanister", () => {
           agent,
           hardwareWallet: true,
         });
-        await governance.listNeurons({ certified: false });
+        await governance.listNeurons({ certified: true });
         expect(agent.call).toBeCalled();
         expect(spyPollForResponse).toBeCalled();
+      });
+
+      it("should not support querying neurons with hardware wallet (only update calls)", async () => {
+        const agent = mock<Agent>();
+        agent.call.mockResolvedValue(agentCallSuccessfulResponse);
+
+        const governance = GovernanceCanister.create({
+          agent,
+          hardwareWallet: true,
+        });
+
+        const call = async () =>
+          await governance.listNeurons({ certified: false });
+
+        await expect(call).rejects.toThrow(new FeatureNotSupportedError());
       });
     });
 

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -273,7 +273,7 @@ describe("GovernanceCanister", () => {
         expect(spyPollForResponse).toBeCalled();
       });
 
-      it("should not support querying neurons with hardware wallet (only update calls)", async () => {
+      it("should not support query neurons with hardware wallet (only update calls)", async () => {
         const agent = mock<Agent>();
         agent.call.mockResolvedValue(agentCallSuccessfulResponse);
 

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -64,6 +64,7 @@ import {
   GovernanceError,
   InsufficientAmountError,
   UnrecognizedTypeError,
+  FeatureNotSupportedError,
 } from "./errors/governance.errors";
 import { ICP } from "./icp";
 import { LedgerCanister } from "./ledger";
@@ -152,6 +153,10 @@ export class GovernanceCanister {
     certified: boolean;
     neuronIds?: NeuronId[];
   }): Promise<NeuronInfo[]> => {
+    if (this.hardwareWallet && !certified) {
+      throw new FeatureNotSupportedError();
+    }
+
     if (this.hardwareWallet) {
       // Hardware Wallet does not support specifying neuronIds.
       return this.listNeuronsHardwareWallet();


### PR DESCRIPTION
# Motivation

List neurons with hardware wallet is only supported through certified  - update - calls.

# Changes

- throw an error if listing neurons is called with `certified: false`
