### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 0.4.3 (2022-06-01)
+
+### Features
+
+- update most recent candid payloads
+
+# 0.4.1 - 0.4.2 (2022-05-23)
+
+### Features
+
+- new methods `disburse`, `mergeMaturity` and `spawnNeuron`
+- expose account utilities
+- expose account identifier utilities
+- update most recent candid payloads
+- remove principal toJSON workaround
+- Hardware wallet compatibility with protobuf
+- add support for `GenesisTokenCanister::claim_neurons`
+
+### Build
+
+- bump dependencies
+
 # 0.4.0 (2022-04-22)
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A library for interfacing with the Internet Computer's Network Nervous System.",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.cjs.js",


### PR DESCRIPTION
# Motivation

Prepare release v0.4.3

Document undocumented changes of v0.4.1 and v0.4.2

Note: not sure if we should not have released v0.5.0 back then but let's go with the flow

@bitdivine once merge can you release a version and tag the release?