### PR TITLE
build: bump agent-js `v0.11.3` with `setBigUint64` for iOS < v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - update most recent candid payloads
 
+### Build
+
+- bump agent-js `v0.11.3` with `setBigUint64` for iOS < v15
+
 # 0.4.1 - 0.4.2 (2022-05-23)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "@dfinity/nns",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^0.11.1",
-        "@dfinity/candid": "^0.11.1",
-        "@dfinity/principal": "^0.11.1",
+        "@dfinity/agent": "^0.11.3",
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3",
         "crc": "^4.1.1",
         "crc-32": "^1.2.2",
         "google-protobuf": "^3.20.1",
@@ -594,9 +594,9 @@
       "dev": true
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.2.tgz",
-      "integrity": "sha512-XCTneh5Oibw7FtcbaFn+umvFNTcfnUByuo6rOCX5mBFMv4+Iqku12btLuqqzDmyE2nSBRaEw7hFvJkNA3aZmQQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.3.tgz",
+      "integrity": "sha512-pqiogLey6S83SG5BS93hBCtXfGRW6tkxa8Y0c9HwxOP/wRoVEuKHdTcOn7rL/HN4mDTwxkdqK4EC1Kv24S1q4Q==",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -605,19 +605,19 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.11.2",
-        "@dfinity/principal": "^0.11.2"
+        "@dfinity/candid": "^0.11.3",
+        "@dfinity/principal": "^0.11.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.2.tgz",
-      "integrity": "sha512-Hzhsln5YtExOQF5hyjBPioC9siNoelaC/Lpz/y0nC0nVvW1RdENbyF99dpAVB1TJySETt6wY6PzCZQqClEojoA=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+      "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA=="
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.2.tgz",
-      "integrity": "sha512-vReWruqIl16yQeKOrCLDLDf2aTEJsXcKeW9qbwVfmV0kwLNE3B2Z6tbRjYbY7s+KwpysD5B1b48ZbIwI00BeyQ=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+      "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -7339,9 +7339,9 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.2.tgz",
-      "integrity": "sha512-XCTneh5Oibw7FtcbaFn+umvFNTcfnUByuo6rOCX5mBFMv4+Iqku12btLuqqzDmyE2nSBRaEw7hFvJkNA3aZmQQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.11.3.tgz",
+      "integrity": "sha512-pqiogLey6S83SG5BS93hBCtXfGRW6tkxa8Y0c9HwxOP/wRoVEuKHdTcOn7rL/HN4mDTwxkdqK4EC1Kv24S1q4Q==",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
@@ -7351,14 +7351,14 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.2.tgz",
-      "integrity": "sha512-Hzhsln5YtExOQF5hyjBPioC9siNoelaC/Lpz/y0nC0nVvW1RdENbyF99dpAVB1TJySETt6wY6PzCZQqClEojoA=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.11.3.tgz",
+      "integrity": "sha512-xX7xNj2lLt7SIlvy0sqNp4fpcTD/xnwEu9APj0tnIF64cnsxIiS12T1Z8jl9g80jCQ1CbRPQf4cfsOfS3Cd2OA=="
     },
     "@dfinity/principal": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.2.tgz",
-      "integrity": "sha512-vReWruqIl16yQeKOrCLDLDf2aTEJsXcKeW9qbwVfmV0kwLNE3B2Z6tbRjYbY7s+KwpysD5B1b48ZbIwI00BeyQ=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.11.3.tgz",
+      "integrity": "sha512-+AJGDJ+RsveybSdxuTQFr2DPNZFpPfXnyixAOFWWdElVniSwnO/SwqQChR0AWvJdy/fKqoAXK+ZzyLG0uqSetA=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "protoc": "bash ./scripts/update_proto.sh"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.11.1",
-    "@dfinity/candid": "^0.11.1",
-    "@dfinity/principal": "^0.11.1",
+    "@dfinity/agent": "^0.11.3",
+    "@dfinity/candid": "^0.11.3",
+    "@dfinity/principal": "^0.11.3",
     "crc": "^4.1.1",
     "crc-32": "^1.2.2",
     "google-protobuf": "^3.20.1",


### PR DESCRIPTION
# Motivation

Few users are still using nns-dapp on iOS < v14. As a temporary solution we provided to nns-js the polyfill for `setBigUint64` we are already using in nns-dapp.

# Changes

- bump agent-js `v0.11.3` 