### PR TITLE
L2-716: Transaction fee method

### DIFF
--- a/src/ledger.spec.ts
+++ b/src/ledger.spec.ts
@@ -59,6 +59,25 @@ describe("LedgerCanister", () => {
       });
     });
 
+    describe("transactionFee", () => {
+      it("returns the transaction fee in e8s", async () => {
+        const fee = BigInt(10_000);
+        const service = mock<LedgerService>();
+        service.transfer_fee.mockResolvedValue({
+          transfer_fee: {
+            e8s: fee,
+          },
+        });
+        const ledger = LedgerCanister.create({
+          serviceOverride: service,
+        });
+
+        const expectedFee = await ledger.transactionFee();
+        expect(service.transfer_fee).toBeCalled();
+        expect(expectedFee).toBe(fee);
+      });
+    });
+
     describe("for hardware wallet", () => {
       it("returns account balance with query call", async () => {
         const queryFetcher = jest

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -97,6 +97,17 @@ export class LedgerCanister {
   };
 
   /**
+   * Returns the transaction fee of the ledger canister
+   * @returns {BigInt}
+   */
+  public transactionFee = async () => {
+    const {
+      transfer_fee: { e8s },
+    } = await this.service.transfer_fee({});
+    return e8s;
+  };
+
+  /**
    * Transfer ICP from the caller to the destination `accountIdentifier`.
    * Returns the index of the block containing the tx if it was successful.
    *
@@ -106,11 +117,12 @@ export class LedgerCanister {
     if (this.hardwareWallet) {
       return this.transferHardwareWallet(request);
     }
+    // When candid is implemented, the previous lines will go away.
+    // But the transaction fee method is not supported by Ledger App yet.
     if (request.fee === undefined) {
-      const {
-        transfer_fee: { e8s },
-      } = await this.service.transfer_fee({});
-      request.fee = e8s;
+      request.fee = this.hardwareWallet
+        ? TRANSACTION_FEE
+        : await this.transactionFee();
     }
     const rawRequest = toTransferRawRequest(request);
     const response = await this.certifiedService.transfer(rawRequest);


### PR DESCRIPTION
# Motivation

Add method to ledger canister to get the transaction fee.

# Changes

* New method "transactionFee" in ledger canister.
* "transfer" method does not get the transfer fee from service if not present and is using a hardware wallet. This part is not used yet, but I fear we'll forget when we remove the protobuf depedency.

# Tests

* Add tests for the "transactionFee" method.
