### PR TITLE
L2-728: Refactor subaccounts type transforms

### DIFF
--- a/src/canisters/ledger/ledger.request.converts.ts
+++ b/src/canisters/ledger/ledger.request.converts.ts
@@ -3,15 +3,13 @@ import {
   TransferArgs as TransferRawRequest,
 } from "../../../candid/ledgerTypes";
 import { ICPTs, Subaccount } from "../../../proto/ledger_pb";
-import {
-  SUB_ACCOUNT_BYTE_LENGTH,
-  TRANSACTION_FEE,
-} from "../../constants/constants";
+import { TRANSACTION_FEE } from "../../constants/constants";
 import { TransferRequest } from "../../types/ledger_converters";
-import { numberToArrayBuffer } from "../../utils/converter.utils";
 
-export const subAccountIdToSubaccount = (subAccountId: number): Subaccount => {
-  const bytes = numberToArrayBuffer(subAccountId, SUB_ACCOUNT_BYTE_LENGTH);
+export const subAccountNumbersToSubaccount = (
+  subAccountNumbers: number[]
+): Subaccount => {
+  const bytes = new Uint8Array(subAccountNumbers).buffer;
   const subaccount: Subaccount = new Subaccount();
   subaccount.setSubAccount(new Uint8Array(bytes));
   return subaccount;
@@ -25,17 +23,12 @@ export const toICPTs = (amount: bigint): ICPTs => {
 
 const e8sToTokens = (e8s: bigint): Tokens => ({ e8s });
 
-export const subAccountIdToNumbers = (subAccountId: number): number[] => {
-  const bytes = numberToArrayBuffer(subAccountId, SUB_ACCOUNT_BYTE_LENGTH);
-  return Array.from(new Uint8Array(bytes));
-};
-
 export const toTransferRawRequest = ({
   to,
   amount,
   memo,
   fee,
-  fromSubAccountId,
+  fromSubAccount,
 }: TransferRequest): TransferRawRequest => ({
   to: to.toNumbers(),
   fee: e8sToTokens(fee ?? TRANSACTION_FEE),
@@ -43,8 +36,5 @@ export const toTransferRawRequest = ({
   // Always explicitly set the memo for compatibility with ledger wallet - hardware wallet
   memo: memo ?? BigInt(0),
   created_at_time: [],
-  from_subaccount:
-    fromSubAccountId === undefined
-      ? []
-      : [subAccountIdToNumbers(fromSubAccountId)],
+  from_subaccount: fromSubAccount === undefined ? [] : [fromSubAccount],
 });

--- a/src/governance.spec.ts
+++ b/src/governance.spec.ts
@@ -204,7 +204,10 @@ describe("GovernanceCanister", () => {
         stake: ICP.fromString("1") as ICP,
         principal: new AnonymousIdentity().getPrincipal(),
         ledgerCanister: mockLedger,
-        fromSubAccountId: 1234,
+        fromSubAccount: [
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ],
       });
 
       expect(mockLedger.transfer).toBeCalled();

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -219,12 +219,12 @@ export class GovernanceCanister {
   public stakeNeuron = async ({
     stake,
     principal,
-    fromSubAccountId,
+    fromSubAccount,
     ledgerCanister,
   }: {
     stake: ICP;
     principal: Principal;
-    fromSubAccountId?: number;
+    fromSubAccount?: number[];
     ledgerCanister: LedgerCanister;
   }): Promise<NeuronId> => {
     if (stake.toE8s() < E8S_PER_ICP) {
@@ -243,7 +243,7 @@ export class GovernanceCanister {
     await ledgerCanister.transfer({
       memo: nonce,
       amount: stake,
-      fromSubAccountId,
+      fromSubAccount,
       to: accountIdentifier,
     });
 

--- a/src/ledger.spec.ts
+++ b/src/ledger.spec.ts
@@ -2,10 +2,7 @@ import { mock } from "jest-mock-extended";
 import { LedgerService } from "../candid/ledger.idl";
 import { Memo, Payment, SendRequest } from "../proto/ledger_pb";
 import { AccountIdentifier } from "./account_identifier";
-import {
-  subAccountIdToNumbers,
-  toICPTs,
-} from "./canisters/ledger/ledger.request.converts";
+import { toICPTs } from "./canisters/ledger/ledger.request.converts";
 import { TRANSACTION_FEE } from "./constants/constants";
 import {
   BadFeeError,
@@ -206,7 +203,10 @@ describe("LedgerCanister", () => {
         });
         const fee = BigInt(10_000);
         const memo = BigInt(0);
-        const fromSubAccountId = 12345;
+        const fromSubAccount = [
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ];
         const ledger = LedgerCanister.create({
           certifiedServiceOverride: service,
         });
@@ -215,7 +215,7 @@ describe("LedgerCanister", () => {
           amount,
           fee,
           memo,
-          fromSubAccountId,
+          fromSubAccount,
         });
 
         expect(service.transfer).toBeCalledWith({
@@ -228,7 +228,7 @@ describe("LedgerCanister", () => {
           },
           memo,
           created_at_time: [],
-          from_subaccount: [subAccountIdToNumbers(fromSubAccountId)],
+          from_subaccount: [fromSubAccount],
         });
       });
 
@@ -455,11 +455,15 @@ describe("LedgerCanister", () => {
             .mockResolvedValue(new Uint8Array(32).fill(0)),
           hardwareWallet: true,
         });
+        const fromSubAccount = [
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ];
 
         const res = await ledger.transfer({
           to,
           amount,
-          fromSubAccountId: 1234,
+          fromSubAccount,
         });
 
         expect(typeof res).toEqual("bigint");

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -12,7 +12,7 @@ import {
 } from "../proto/ledger_pb";
 import { AccountIdentifier } from "./account_identifier";
 import {
-  subAccountIdToSubaccount,
+  subAccountNumbersToSubaccount,
   toICPTs,
   toTransferRawRequest,
 } from "./canisters/ledger/ledger.request.converts";
@@ -161,7 +161,7 @@ export class LedgerCanister {
     amount,
     memo,
     fee,
-    fromSubAccountId,
+    fromSubAccount,
   }: TransferRequest): Promise<BlockHeight> => {
     const request = new SendRequest();
     request.setTo(to.toProto());
@@ -177,8 +177,8 @@ export class LedgerCanister {
     requestMemo.setMemo((memo ?? BigInt(0)).toString());
     request.setMemo(requestMemo);
 
-    if (fromSubAccountId !== undefined) {
-      request.setFromSubaccount(subAccountIdToSubaccount(fromSubAccountId));
+    if (fromSubAccount !== undefined) {
+      request.setFromSubaccount(subAccountNumbersToSubaccount(fromSubAccount));
     }
 
     try {

--- a/src/types/ledger_converters.ts
+++ b/src/types/ledger_converters.ts
@@ -7,5 +7,5 @@ export type TransferRequest = {
   amount: ICP;
   memo?: bigint;
   fee?: E8s;
-  fromSubAccountId?: number;
+  fromSubAccount?: number[];
 };

--- a/src/utils/converter.utils.ts
+++ b/src/utils/converter.utils.ts
@@ -34,15 +34,6 @@ export const arrayOfNumberToArrayBuffer = (
   return arrayOfNumberToUint8Array(numbers).buffer;
 };
 
-export const numberToArrayBuffer = (
-  value: number,
-  byteLength: number
-): ArrayBuffer => {
-  const buffer = new ArrayBuffer(byteLength);
-  new DataView(buffer).setUint32(byteLength - 4, value);
-  return buffer;
-};
-
 export const asciiStringToByteArray = (text: string): Array<number> => {
   return Array.from(text).map((c) => c.charCodeAt(0));
 };


### PR DESCRIPTION
# Motivation

Simplify the conversion of subaccounts from one type to another.

# Changes

* Subaccount is kept as array of numbers whichis needed for the Ledger Canister candid implementation.
* Adapt the protobuf converter.

# Tests

* Fix tests to adapt to new type.
